### PR TITLE
Mandatory atom entry fields

### DIFF
--- a/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
@@ -9,28 +9,38 @@ namespace Grean.AtomEventStore.UnitTests
 {
     public class SyndicationItemBuilder
     {
+        private readonly DateTimeOffset publishDate;
         private readonly SyndicationContent content;
 
         public SyndicationItemBuilder()
             : this(
+                DateTimeOffset.Now,
                 SyndicationContent.CreatePlaintextContent(""))
         {
         }
 
-        private SyndicationItemBuilder(SyndicationContent content)
+        private SyndicationItemBuilder(
+            DateTimeOffset publishDate,
+            SyndicationContent content)
         {
+            this.publishDate = publishDate;
             this.content = content;
         }
 
         public SyndicationItemBuilder WithXmlContent(object content)
         {
             var sc = XmlSyndicationContent.CreateXmlContent(content);
-            return new SyndicationItemBuilder(sc);
+            return new SyndicationItemBuilder(this.publishDate, sc);
         }
 
         public SyndicationItem Build()
         {
-            return new SyndicationItem { Content = this.content };
+            return new SyndicationItem
+            {
+                PublishDate = this.publishDate,
+                LastUpdatedTime = this.publishDate,
+                Content = this.content 
+            };
         }
     }
 }

--- a/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
@@ -12,8 +12,9 @@ namespace Grean.AtomEventStore.UnitTests
         private readonly SyndicationContent content;
 
         public SyndicationItemBuilder()
+            : this(
+                SyndicationContent.CreatePlaintextContent(""))
         {
-            this.content = SyndicationContent.CreatePlaintextContent("");
         }
 
         private SyndicationItemBuilder(SyndicationContent content)

--- a/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
@@ -26,6 +26,7 @@ namespace Grean.AtomEventStore.UnitTests
             if (other != null)
                 return IsCorrectId(other.Id)
                     && HasCorrectTitle(other)
+                    && this.HasCorrectDates(other)
                     && HasCorrectAuthors(other.Authors)
                     && this.contentComparer.Equals(
                         this.item.Content, other.Content);
@@ -57,6 +58,13 @@ namespace Grean.AtomEventStore.UnitTests
             var expectedTitle = "Changeset " + (Guid)id;
             return candidate.Title != null
                 && candidate.Title.Text == expectedTitle;
+        }
+
+        private bool HasCorrectDates(SyndicationItem other)
+        {
+            return this.item.PublishDate <= other.PublishDate
+                && other.PublishDate <= DateTimeOffset.Now
+                && other.PublishDate == other.LastUpdatedTime;
         }
 
         private class SyndicationContentComparer : 

--- a/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
@@ -25,6 +25,7 @@ namespace Grean.AtomEventStore.UnitTests
             var other = obj as SyndicationItem;
             if (other != null)
                 return IsCorrectId(other.Id)
+                    && HasCorrectTitle(other)
                     && HasCorrectAuthors(other.Authors)
                     && this.contentComparer.Equals(
                         this.item.Content, other.Content);
@@ -46,6 +47,16 @@ namespace Grean.AtomEventStore.UnitTests
             IEnumerable<SyndicationPerson> candidate)
         {
             return candidate.Any(p => !string.IsNullOrWhiteSpace(p.Name));
+        }
+
+        private static bool HasCorrectTitle(SyndicationItem candidate)
+        {
+            UuidIri id;
+            UuidIri.TryParse(candidate.Id, out id);
+
+            var expectedTitle = "Changeset " + (Guid)id;
+            return candidate.Title != null
+                && candidate.Title.Text == expectedTitle;
         }
 
         private class SyndicationContentComparer : 

--- a/AtomEventStore.UnitTests/UuidIriTests.cs
+++ b/AtomEventStore.UnitTests/UuidIriTests.cs
@@ -113,5 +113,14 @@ namespace Grean.AtomEventStore.UnitTests
             Assert.False(couldParse, "TryParse should fail.");
             Assert.Equal(default(UuidIri), actual);
         }
+
+        [Fact]
+        public void NewIdReturnsUniqueId()
+        {
+            var x = UuidIri.NewId();
+            var y = UuidIri.NewId();
+
+            Assert.NotEqual(x, y);
+        }
     }
 }

--- a/AtomEventStore/SyndicationStore.cs
+++ b/AtomEventStore/SyndicationStore.cs
@@ -30,6 +30,8 @@ namespace Grean.AtomEventStore
                 item.Id = changesetId.ToString();
                 item.Title = new TextSyndicationContent(
                     "Changeset " + (Guid)changesetId);
+                item.PublishDate = DateTimeOffset.Now;
+                item.LastUpdatedTime = item.PublishDate;
                 item.Authors.Add(new SyndicationPerson { Name = "Grean" });
                 item.Content = XmlSyndicationContent.CreateXmlContent(@event);
                 this.entryWriter.Create(item);

--- a/AtomEventStore/SyndicationStore.cs
+++ b/AtomEventStore/SyndicationStore.cs
@@ -24,8 +24,12 @@ namespace Grean.AtomEventStore
         {
             return Task.Factory.StartNew(() =>
             {
+                var changesetId = UuidIri.NewId();
+
                 var item = new SyndicationItem();
-                item.Id = UuidIri.NewId().ToString();
+                item.Id = changesetId.ToString();
+                item.Title = new TextSyndicationContent(
+                    "Changeset " + (Guid)changesetId);
                 item.Authors.Add(new SyndicationPerson { Name = "Grean" });
                 item.Content = XmlSyndicationContent.CreateXmlContent(@event);
                 this.entryWriter.Create(item);

--- a/AtomEventStore/SyndicationStore.cs
+++ b/AtomEventStore/SyndicationStore.cs
@@ -25,7 +25,7 @@ namespace Grean.AtomEventStore
             return Task.Factory.StartNew(() =>
             {
                 var item = new SyndicationItem();
-                item.Id = "urn:uuid:" + Guid.NewGuid();
+                item.Id = UuidIri.NewId().ToString();
                 item.Authors.Add(new SyndicationPerson { Name = "Grean" });
                 item.Content = XmlSyndicationContent.CreateXmlContent(@event);
                 this.entryWriter.Create(item);

--- a/AtomEventStore/UuidIri.cs
+++ b/AtomEventStore/UuidIri.cs
@@ -44,5 +44,10 @@ namespace Grean.AtomEventStore
             uuidIri = default(UuidIri);
             return false;
         }
+
+        public static UuidIri NewId()
+        {
+            return new UuidIri(Guid.NewGuid());
+        }
     }
 }


### PR DESCRIPTION
This pull request ensures that remaining mandatory Atom entry fields are populated before the syndication item is saved.
