### PR TITLE
Syndication item in head

### DIFF
--- a/AtomEventStore.UnitTests/SyndicationEnvy.cs
+++ b/AtomEventStore.UnitTests/SyndicationEnvy.cs
@@ -20,5 +20,16 @@ namespace Grean.AtomEventStore.UnitTests
         {
             return new SyndicationFeedResemblance(syndicationFeed);
         }
+
+        public static SyndicationItem ChangeLinkRelationShipTypes(
+            this SyndicationItem syndicationItem,
+            string from,
+            string to)
+        {
+            var newItem = syndicationItem.Clone();
+            foreach (var l in newItem.Links.Where(l => l.RelationshipType == from))
+                l.RelationshipType = to;
+            return newItem;
+        }
     }
 }

--- a/AtomEventStore.UnitTests/SyndicationFeedBuilder.cs
+++ b/AtomEventStore.UnitTests/SyndicationFeedBuilder.cs
@@ -27,7 +27,7 @@ namespace Grean.AtomEventStore.UnitTests
 
         public SyndicationFeed Build()
         {
-            var feed = new SyndicationFeed();
+            var feed = new SyndicationFeed(new List<SyndicationItem>());
             feed.Id = this.feedId;
             feed.Links.Add(
                 new SyndicationLink

--- a/AtomEventStore.UnitTests/SyndicationFeedBuilder.cs
+++ b/AtomEventStore.UnitTests/SyndicationFeedBuilder.cs
@@ -9,25 +9,38 @@ namespace Grean.AtomEventStore.UnitTests
     public class SyndicationFeedBuilder
     {
         private readonly string feedId;
+        private readonly IEnumerable<SyndicationItem> items;
 
         public SyndicationFeedBuilder()
-            : this(Guid.NewGuid().ToString())
+            : this(
+                Guid.NewGuid().ToString(),
+                Enumerable.Empty<SyndicationItem>())
         {
         }
 
-        private SyndicationFeedBuilder(string feedId)
+        private SyndicationFeedBuilder(
+            string feedId,
+            IEnumerable<SyndicationItem> items)
         {
             this.feedId = feedId;
+            this.items = items;
         }
 
-        public SyndicationFeedBuilder WithFeedId(string feedId)
+        public SyndicationFeedBuilder WithFeedId(string newFeedId)
         {
-            return new SyndicationFeedBuilder(feedId);
+            return new SyndicationFeedBuilder(newFeedId, this.items);
+        }
+
+        public SyndicationFeedBuilder WithItem(SyndicationItem newItem)
+        {
+            return new SyndicationFeedBuilder(
+                this.feedId,
+                this.items.Concat(new[] { newItem }));
         }
 
         public SyndicationFeed Build()
         {
-            var feed = new SyndicationFeed(new List<SyndicationItem>());
+            var feed = new SyndicationFeed(this.items.ToList());
             feed.Id = this.feedId;
             feed.Links.Add(
                 new SyndicationLink

--- a/AtomEventStore.UnitTests/SyndicationFeedResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationFeedResemblance.cs
@@ -24,7 +24,8 @@ namespace Grean.AtomEventStore.UnitTests
                     && this.HasCorrectLinks(other.Links)
                     && this.HasCorrectDate(other.LastUpdatedTime)
                     && this.HasCorrectTitle(other.Title)
-                    && HasCorrectAuthors(other.Authors);
+                    && HasCorrectAuthors(other.Authors)
+                    && this.HasCorrectItems(other.Items);
             return base.Equals(obj);
         }
 
@@ -46,8 +47,10 @@ namespace Grean.AtomEventStore.UnitTests
         {
             public bool Equals(SyndicationLink x, SyndicationLink y)
             {
-                return object.Equals(x.RelationshipType, y.RelationshipType)
-                    && object.Equals(x.Uri, y.Uri);
+                return (x.RelationshipType == "via"
+                    && y.RelationshipType == "via")
+                    || (object.Equals(x.RelationshipType, y.RelationshipType)
+                    && object.Equals(x.Uri, y.Uri));
             }
 
             public int GetHashCode(SyndicationLink obj)
@@ -74,6 +77,11 @@ namespace Grean.AtomEventStore.UnitTests
             IEnumerable<SyndicationPerson> candidate)
         {
             return candidate.Any(p => !string.IsNullOrWhiteSpace(p.Name));
+        }
+
+        private bool HasCorrectItems(IEnumerable<SyndicationItem> candidates)
+        {
+            return this.Items.SequenceEqual(candidates);
         }
     }
 }

--- a/AtomEventStore.UnitTests/SyndicationFeedResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationFeedResemblance.cs
@@ -11,18 +11,16 @@ namespace Grean.AtomEventStore.UnitTests
 {
     public class SyndicationFeedResemblance : SyndicationFeed
     {
-        private readonly SyndicationFeed feed;
-
         public SyndicationFeedResemblance(SyndicationFeed feed)
+            : base(feed, true)
         {
-            this.feed = feed;
         }
 
         public override bool Equals(object obj)
         {
             var other = obj as SyndicationFeed;
             if (other != null)
-                return object.Equals(this.feed.Id, other.Id)
+                return object.Equals(this.Id, other.Id)
                     && this.HasCorrectLinks(other.Links)
                     && this.HasCorrectDate(other.LastUpdatedTime)
                     && this.HasCorrectTitle(other.Title)
@@ -38,7 +36,7 @@ namespace Grean.AtomEventStore.UnitTests
         private bool HasCorrectLinks(IEnumerable<SyndicationLink> candidates)
         {
             var expected = new HashSet<SyndicationLink>(
-                this.feed.Links,
+                this.Links,
                 new SyndicationLinkComparer());
             return expected.SetEquals(candidates);
         }
@@ -62,13 +60,13 @@ namespace Grean.AtomEventStore.UnitTests
         {
             return candidate != null
                 && object.Equals(
-                    "Head of event stream " + this.feed.Id,
+                    "Head of event stream " + this.Id,
                     candidate.Text);
         }
 
         private bool HasCorrectDate(DateTimeOffset candidate)
         {
-            return this.feed.LastUpdatedTime <= candidate
+            return this.LastUpdatedTime <= candidate
                 && candidate <= DateTimeOffset.Now;
         }
 

--- a/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
@@ -11,36 +11,48 @@ namespace Grean.AtomEventStore.UnitTests
     {
         private readonly DateTimeOffset publishDate;
         private readonly SyndicationContent content;
+        private readonly IEnumerable<SyndicationLink> links;
 
         public SyndicationItemBuilder()
             : this(
                 DateTimeOffset.Now,
-                SyndicationContent.CreatePlaintextContent(""))
+                SyndicationContent.CreatePlaintextContent(""),
+                new []
+                {
+                    new SyndicationLink
+                    { 
+                        RelationshipType = "self",
+                        Uri = new Uri(Guid.NewGuid().ToString(), UriKind.Relative)
+                    }
+                })
         {
         }
 
         private SyndicationItemBuilder(
             DateTimeOffset publishDate,
-            SyndicationContent content)
+            SyndicationContent content,
+            IEnumerable<SyndicationLink> links)
         {
             this.publishDate = publishDate;
             this.content = content;
+            this.links = links;
         }
 
         public SyndicationItemBuilder WithXmlContent(object content)
         {
             var sc = XmlSyndicationContent.CreateXmlContent(content);
-            return new SyndicationItemBuilder(this.publishDate, sc);
+            return new SyndicationItemBuilder(this.publishDate, sc, this.links);
         }
 
         public SyndicationItem Build()
         {
-            return new SyndicationItem
-            {
-                PublishDate = this.publishDate,
-                LastUpdatedTime = this.publishDate,
-                Content = this.content 
-            };
+            var item = new SyndicationItem();
+            item.PublishDate = this.publishDate;
+            item.LastUpdatedTime = this.publishDate;
+            item.Content = this.content;
+            foreach (var l in this.links)
+                item.Links.Add(l);
+            return item;
         }
     }
 }

--- a/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
@@ -38,6 +38,11 @@ namespace Grean.AtomEventStore.UnitTests
             return 0;
         }
 
+        public override SyndicationItem Clone()
+        {
+            return new SyndicationItemResemblance(this);
+        }
+
         private static bool IsCorrectId(string candidate)
         {
             UuidIri dummy;
@@ -84,7 +89,9 @@ namespace Grean.AtomEventStore.UnitTests
 
             public bool Equals(SyndicationLink x, SyndicationLink y)
             {
-                if (y.RelationshipType == "self")
+                if (x.RelationshipType == "self" && y.RelationshipType == "self")
+                    return y.Uri == this.expectedSelfUri;
+                if (x.RelationshipType == "via" && y.RelationshipType == "via")
                     return y.Uri == this.expectedSelfUri;
                 return object.Equals(x.RelationshipType, y.RelationshipType)
                     && object.Equals(x.Uri, y.Uri);

--- a/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
@@ -12,12 +12,11 @@ namespace Grean.AtomEventStore.UnitTests
     public class SyndicationItemResemblance : SyndicationItem
     {
         private readonly SyndicationContentComparer contentComparer;
-        private readonly SyndicationItem item;
 
         public SyndicationItemResemblance(SyndicationItem item)
+            : base(item)
         {
             this.contentComparer = new SyndicationContentComparer();
-            this.item = item;
         }
 
         public override bool Equals(object obj)
@@ -30,7 +29,7 @@ namespace Grean.AtomEventStore.UnitTests
                     && this.HasCorrectDates(other)
                     && HasCorrectAuthors(other.Authors)
                     && this.contentComparer.Equals(
-                        this.item.Content, other.Content);
+                        this.Content, other.Content);
             return base.Equals(obj);
         }
 
@@ -75,12 +74,12 @@ namespace Grean.AtomEventStore.UnitTests
 
         private bool HasCorrectDates(SyndicationItem other)
         {
-            return this.item.PublishDate <= other.PublishDate
+            return this.PublishDate <= other.PublishDate
                 && other.PublishDate <= DateTimeOffset.Now
                 && other.PublishDate == other.LastUpdatedTime;
         }
 
-        private class SyndicationContentComparer : 
+        private class SyndicationContentComparer :
             IEqualityComparer<SyndicationContent>
         {
             public bool Equals(SyndicationContent x, SyndicationContent y)

--- a/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
@@ -26,6 +26,7 @@ namespace Grean.AtomEventStore.UnitTests
             if (other != null)
                 return IsCorrectId(other.Id)
                     && HasCorrectTitle(other)
+                    && HasCorrectLinks(other)
                     && this.HasCorrectDates(other)
                     && HasCorrectAuthors(other.Authors)
                     && this.contentComparer.Equals(
@@ -58,6 +59,20 @@ namespace Grean.AtomEventStore.UnitTests
             var expectedTitle = "Changeset " + (Guid)id;
             return candidate.Title != null
                 && candidate.Title.Text == expectedTitle;
+        }
+
+        private static bool HasCorrectLinks(SyndicationItem candidate)
+        {
+            UuidIri changesetId;
+            UuidIri.TryParse(candidate.Id, out changesetId);
+            var expectedUri =
+                new Uri(((Guid)changesetId).ToString(), UriKind.Relative);
+            Func<SyndicationLink, bool> isCorrectSelfLink = l =>
+                l.RelationshipType == "self" &&
+                l.Uri == expectedUri;
+
+            return candidate != null
+                && candidate.Links.Count(isCorrectSelfLink) == 1;
         }
 
         private bool HasCorrectDates(SyndicationItem other)

--- a/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemResemblance.cs
@@ -53,8 +53,7 @@ namespace Grean.AtomEventStore.UnitTests
 
         private static bool HasCorrectTitle(SyndicationItem candidate)
         {
-            UuidIri id;
-            UuidIri.TryParse(candidate.Id, out id);
+            var id = UuidIri.Parse(candidate.Id);
 
             var expectedTitle = "Changeset " + (Guid)id;
             return candidate.Title != null
@@ -63,8 +62,7 @@ namespace Grean.AtomEventStore.UnitTests
 
         private static bool HasCorrectLinks(SyndicationItem candidate)
         {
-            UuidIri changesetId;
-            UuidIri.TryParse(candidate.Id, out changesetId);
+            var changesetId = UuidIri.Parse(candidate.Id);
             var expectedUri =
                 new Uri(((Guid)changesetId).ToString(), UriKind.Relative);
             Func<SyndicationLink, bool> isCorrectSelfLink = l =>

--- a/AtomEventStore.UnitTests/SyndicationStoreTests.cs
+++ b/AtomEventStore.UnitTests/SyndicationStoreTests.cs
@@ -30,7 +30,7 @@ namespace Grean.AtomEventStore.UnitTests
                 .Build()
                 .ToResemblance();
 
-            var expectedFeedItem = expectedEntry.ToResemblance();
+            var expectedFeedItem = expectedEntry.Clone().ToResemblance();
             var itemSelfLink = expectedFeedItem.Links
                 .Single(l => l.RelationshipType == "self");
             itemSelfLink.RelationshipType = "via";

--- a/AtomEventStore.UnitTests/SyndicationStoreTests.cs
+++ b/AtomEventStore.UnitTests/SyndicationStoreTests.cs
@@ -30,10 +30,10 @@ namespace Grean.AtomEventStore.UnitTests
                 .Build()
                 .ToResemblance();
 
-            var expectedFeedItem = expectedEntry.Clone().ToResemblance();
-            var itemSelfLink = expectedFeedItem.Links
-                .Single(l => l.RelationshipType == "self");
-            itemSelfLink.RelationshipType = "via";
+            var expectedFeedItem = expectedEntry
+                .Clone()
+                .ChangeLinkRelationShipTypes(from: "self", to: "via")
+                .ToResemblance();
             var expectedHead = new SyndicationFeedBuilder()
                 .WithFeedId(id)
                 .WithItem(expectedFeedItem)

--- a/AtomEventStore.UnitTests/SyndicationStoreTests.cs
+++ b/AtomEventStore.UnitTests/SyndicationStoreTests.cs
@@ -30,13 +30,12 @@ namespace Grean.AtomEventStore.UnitTests
                 .Build()
                 .ToResemblance();
 
-            var expectedFeedItem = expectedEntry
-                .Clone()
-                .ChangeLinkRelationShipTypes(from: "self", to: "via")
-                .ToResemblance();
             var expectedHead = new SyndicationFeedBuilder()
                 .WithFeedId(id)
-                .WithItem(expectedFeedItem)
+                .WithItem(expectedEntry
+                    .Clone()
+                    .ChangeLinkRelationShipTypes(from: "self", to: "via")
+                    .ToResemblance())
                 .Build()
                 .ToResemblance();
 

--- a/AtomEventStore.UnitTests/SyndicationStoreTests.cs
+++ b/AtomEventStore.UnitTests/SyndicationStoreTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using System.Xml;
 using System.Xml.Linq;
 using Xunit;
+using System.ServiceModel.Syndication;
 
 namespace Grean.AtomEventStore.UnitTests
 {

--- a/AtomEventStore.UnitTests/UuidIriTests.cs
+++ b/AtomEventStore.UnitTests/UuidIriTests.cs
@@ -64,54 +64,59 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void TryParseCorrectlyFormattedStringReturnsCorrectResult(
+        public void ParseCorrectlyFormattedStringReturnsCorrectResult(
             UuidIri expected)
         {
             var correctlyFormatted = expected.ToString();
 
-            UuidIri actual;
-            bool couldParse = UuidIri.TryParse(correctlyFormatted, out actual);
+            UuidIri actualFromTry;
+            bool couldParse = UuidIri.TryParse(correctlyFormatted, out actualFromTry);
+            UuidIri actual = UuidIri.Parse(correctlyFormatted);
 
             Assert.True(couldParse, "TryParse should succeed.");
+            Assert.Equal(expected, actualFromTry);
             Assert.Equal(expected, actual);
         }
 
         [Theory, AutoAtomData]
-        public void TryParseIncorrectlyPrefixedStringReturnsCorrectResult(
+        public void ParseIncorrectlyPrefixedStringReturnsCorrectResult(
             string incorrectPrefix,
             Guid guid)
         {
             Assert.NotEqual("urn:uuid:", incorrectPrefix);
             var inccorectlyPrefixed = incorrectPrefix + guid;
 
-            UuidIri actual;
-            bool couldParse = UuidIri.TryParse(inccorectlyPrefixed, out actual);
+            UuidIri actualFromTry;
+            bool couldParse = UuidIri.TryParse(inccorectlyPrefixed, out actualFromTry);
+            Assert.Throws<ArgumentException>(() => UuidIri.Parse(inccorectlyPrefixed));
 
             Assert.False(couldParse, "TryParse should fail.");
-            Assert.Equal(default(UuidIri), actual);
+            Assert.Equal(default(UuidIri), actualFromTry);
         }
 
         [Theory, AutoAtomData]
-        public void TryParseStringWithIncorrectIdReturnsCorrectResult(
+        public void ParseStringWithIncorrectIdReturnsCorrectResult(
             DateTimeOffset notAGuid)
         {
             var incorrectlyIdd = "urn:uuid:" + notAGuid.ToString();
 
-            UuidIri actual;
-            bool couldParse = UuidIri.TryParse(incorrectlyIdd, out actual);
+            UuidIri actualFromTry;
+            bool couldParse = UuidIri.TryParse(incorrectlyIdd, out actualFromTry);
+            Assert.Throws<ArgumentException>(() => UuidIri.Parse(incorrectlyIdd));
 
             Assert.False(couldParse, "TryParse should fail.");
-            Assert.Equal(default(UuidIri), actual);
+            Assert.Equal(default(UuidIri), actualFromTry);
         }
 
         [Theory, AutoAtomData]
-        public void TryParseNullReturnsCorrectResult()
+        public void ParseNullReturnsCorrectResult()
         {
-            UuidIri actual;
-            bool couldParse = UuidIri.TryParse(null, out actual);
+            UuidIri actualFromTry;
+            bool couldParse = UuidIri.TryParse(null, out actualFromTry);
+            Assert.Throws<ArgumentNullException>(() => UuidIri.Parse(null));
 
             Assert.False(couldParse, "TryParse should fail.");
-            Assert.Equal(default(UuidIri), actual);
+            Assert.Equal(default(UuidIri), actualFromTry);
         }
 
         [Fact]

--- a/AtomEventStore/SyndicationStore.cs
+++ b/AtomEventStore/SyndicationStore.cs
@@ -28,45 +28,62 @@ namespace Grean.AtomEventStore
                 var changesetAddress =
                     new Uri(((Guid)changesetId).ToString(), UriKind.Relative);
 
-                var item = new SyndicationItem();
-                item.Id = changesetId.ToString();
-                item.Title = new TextSyndicationContent(
-                    "Changeset " + (Guid)changesetId);
-                item.Links.Add(
-                    new SyndicationLink
-                    {
-                        RelationshipType = "self",
-                        Uri = changesetAddress
-                    });
-                item.PublishDate = DateTimeOffset.Now;
-                item.LastUpdatedTime = item.PublishDate;
-                item.Authors.Add(new SyndicationPerson { Name = "Grean" });
-                item.Content = XmlSyndicationContent.CreateXmlContent(@event);
+                var item = CreateItem(@event, changesetId, changesetAddress);
                 this.entryWriter.Create(item);
 
-                var feedItem = item.Clone();
-                feedItem.Links.Clear();
-                feedItem.Links.Add(
-                    new SyndicationLink
-                    {
-                        RelationshipType = "via",
-                        Uri = changesetAddress
-                    });
-
-                var feed = new SyndicationFeed(new[] { feedItem });
-                feed.Id = id;
-                feed.Title = new TextSyndicationContent(
-                    "Head of event stream " + id);
-                feed.Links.Add(
-                    new SyndicationLink
-                    {
-                        RelationshipType = "self",
-                        Uri = new Uri(id, UriKind.Relative)
-                    });
-                feed.LastUpdatedTime = DateTimeOffset.Now;
-                feed.Authors.Add(new SyndicationPerson { Name = "Grean" });
-                this.headWriter.CreateOrUpdate(feed);
+                this.CreateOrUpdateHead(id, changesetAddress, item);
             });
+        }
+
+        private static SyndicationItem CreateItem(
+            object @event,
+            UuidIri changesetId,
+            Uri changesetAddress)
+        {
+            var item = new SyndicationItem();
+            item.Id = changesetId.ToString();
+            item.Title = new TextSyndicationContent(
+                "Changeset " + (Guid)changesetId);
+            item.Links.Add(
+                new SyndicationLink
+                {
+                    RelationshipType = "self",
+                    Uri = changesetAddress
+                });
+            item.PublishDate = DateTimeOffset.Now;
+            item.LastUpdatedTime = item.PublishDate;
+            item.Authors.Add(new SyndicationPerson { Name = "Grean" });
+            item.Content = XmlSyndicationContent.CreateXmlContent(@event);
+            return item;
+        }
+
+        private void CreateOrUpdateHead(
+            string id,
+            Uri changesetAddress,
+            SyndicationItem item)
+        {
+            var feedItem = item.Clone();
+            feedItem.Links.Clear();
+            feedItem.Links.Add(
+                new SyndicationLink
+                {
+                    RelationshipType = "via",
+                    Uri = changesetAddress
+                });
+
+            var feed = new SyndicationFeed(new[] { feedItem });
+            feed.Id = id;
+            feed.Title = new TextSyndicationContent(
+                "Head of event stream " + id);
+            feed.Links.Add(
+                new SyndicationLink
+                {
+                    RelationshipType = "self",
+                    Uri = new Uri(id, UriKind.Relative)
+                });
+            feed.LastUpdatedTime = DateTimeOffset.Now;
+            feed.Authors.Add(new SyndicationPerson { Name = "Grean" });
+            this.headWriter.CreateOrUpdate(feed);
         }
     }
 }

--- a/AtomEventStore/SyndicationStore.cs
+++ b/AtomEventStore/SyndicationStore.cs
@@ -30,6 +30,12 @@ namespace Grean.AtomEventStore
                 item.Id = changesetId.ToString();
                 item.Title = new TextSyndicationContent(
                     "Changeset " + (Guid)changesetId);
+                item.Links.Add(
+                    new SyndicationLink
+                    {
+                        RelationshipType = "self",
+                        Uri = new Uri(((Guid)changesetId).ToString(), UriKind.Relative)
+                    });
                 item.PublishDate = DateTimeOffset.Now;
                 item.LastUpdatedTime = item.PublishDate;
                 item.Authors.Add(new SyndicationPerson { Name = "Grean" });

--- a/AtomEventStore/UuidIri.cs
+++ b/AtomEventStore/UuidIri.cs
@@ -45,6 +45,22 @@ namespace Grean.AtomEventStore
             return false;
         }
 
+        public static UuidIri Parse(string candidate)
+        {
+            if (candidate == null)
+                throw new ArgumentNullException("candidate");
+
+            UuidIri parsedUuid;
+            var couldParse = UuidIri.TryParse(candidate, out parsedUuid);
+            if (!couldParse)
+                throw new ArgumentException(
+                    string.Format(
+                        "The candidate string is not a correctly formatted UUID IRI. The valid format is: \"urn:uuid:<Guid value>\". Example: \"urn:uuid:7eddb2e3-369b-4f3d-8697-520bc5de8ed4\". The actual candidate string was: \"{0}\"",
+                        candidate),
+                    "candidate");
+            return parsedUuid;
+        }
+
         public static UuidIri NewId()
         {
             return new UuidIri(Guid.NewGuid());


### PR DESCRIPTION
This pull request adds the newly created syndication item (Atom entry) to the head feed, as the only resource.

This is effectively the pointer from the head to the most recent changeset.
