### PR TITLE
Used XmlSerializer instd of DataContractSerializer

### DIFF
--- a/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
+++ b/AtomEventStore.UnitTests/SyndicationItemBuilder.cs
@@ -40,7 +40,10 @@ namespace Grean.AtomEventStore.UnitTests
 
         public SyndicationItemBuilder WithXmlContent(object content)
         {
-            var sc = XmlSyndicationContent.CreateXmlContent(content);
+            var sc = new XmlSyndicationContent(
+                "application/xml",
+                content,
+                new XmlSerializer(content.GetType()));
             return new SyndicationItemBuilder(this.publishDate, sc, this.links);
         }
 

--- a/AtomEventStore/AtomEventStore.csproj
+++ b/AtomEventStore/AtomEventStore.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/AtomEventStore/SyndicationEventStream.cs
+++ b/AtomEventStore/SyndicationEventStream.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.ServiceModel.Syndication;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 
 namespace Grean.AtomEventStore
 {
@@ -63,7 +64,10 @@ namespace Grean.AtomEventStore
             item.PublishDate = DateTimeOffset.Now;
             item.LastUpdatedTime = item.PublishDate;
             item.Authors.Add(new SyndicationPerson { Name = "Grean" });
-            item.Content = XmlSyndicationContent.CreateXmlContent(@event);
+            item.Content = new XmlSyndicationContent(
+                "application/xml",
+                @event,
+                new XmlSerializer(typeof(T)));
             return item;
         }
 
@@ -118,7 +122,7 @@ namespace Grean.AtomEventStore
             while (item != null)
             {
                 var content = (XmlSyndicationContent)item.Content;
-                yield return content.ReadContent<T>();
+                yield return content.ReadContent<T>(new XmlSerializer(typeof(T)));
                 item = this.GetPrevious(item);
             }
         }


### PR DESCRIPTION
because when serializing/deserializing Atom (or RSS, for that matter), we
are already explicitly dealing with XML, and we might as well be explicit
about this.
There are things that the default DataContractSerializer can't do, such as
handle XML attributes, and there's no reason to limit ourselves from using
XML attributes. Thus, I think that the default serializer should be an
XmlSerializer.
