### PR TITLE
Refactor to paged feeds

### DIFF
--- a/AtomEventStore.AzureBlob/AtomEventsOnAzure.cs
+++ b/AtomEventStore.AzureBlob/AtomEventsOnAzure.cs
@@ -18,25 +18,6 @@ namespace Grean.AtomEventStore.AzureBlob
             this.container = container;
         }
 
-        public XmlReader CreateEntryReaderFor(Uri href)
-        {
-            var blobRef = this.CreateBlobReference(href);
-            return XmlReader.Create(
-                blobRef.OpenRead(),
-                new XmlReaderSettings { CloseInput = true });
-        }
-
-        public XmlWriter CreateEntryWriterFor(AtomEntry atomEntry)
-        {
-            if (atomEntry == null)
-                throw new ArgumentNullException("atomEntry");
-
-            var blobRef = this.CreateBlobReference(atomEntry.Links);            
-            return XmlWriter.Create(
-                blobRef.OpenWrite(),
-                new XmlWriterSettings { CloseOutput = true });
-        }
-
         public XmlReader CreateFeedReaderFor(Uri href)
         {
             var blobRef = this.CreateBlobReference(href);

--- a/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
+++ b/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="EnvelopeTypeConverter.cs" />
     <Compile Include="ITestEvent.cs" />
     <Compile Include="ITestEventVisitor.cs" />
+    <Compile Include="SpyAtomEventStore.cs" />
     <Compile Include="SubNs\SubSubNs\TestEventS.cs" />
     <Compile Include="TestEventD.cs" />
     <Compile Include="TestEventU.cs" />

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -70,6 +70,48 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
+        public void IsPreviousFeedLinkReturnsTrueForPreviousFeedLink(
+            UuidIri id)
+        {
+            var link = AtomEventStream.CreatePreviousLinkFrom(id);
+            bool actual = AtomEventStream.IsPreviousFeedLink(link);
+            Assert.True(actual);
+        }
+
+        [Theory, AutoAtomData]
+        public void IsPreviousFeedLinkReturnsFalsForLinkWithIncorrectRel(
+            UuidIri id)
+        {
+            var link = AtomEventStream.CreateSelfLinkFrom(id);
+            var actual = AtomEventStream.IsPreviousFeedLink(link);
+            Assert.False(actual);
+        }
+
+        [Theory, AutoAtomData]
+        public void IsPreviousFeedLinkReturnsFalseForLinkWithAbsoluteUri(
+            Uri uri)
+        {
+            Assert.True(uri.IsAbsoluteUri);
+            var link = AtomLink.CreatePreviousLink(uri);
+
+            var actual = AtomEventStream.IsPreviousFeedLink(link);
+
+            Assert.False(actual);
+        }
+
+        [Theory, AutoAtomData]
+        public void IsPreviousFeedLinkReturnsFalseForLinkNotUuid(
+            int number)
+        {
+            var uri = new Uri(number.ToString(), UriKind.Relative);
+            var link = AtomLink.CreatePreviousLink(uri);
+
+            var actual = AtomEventStream.IsPreviousFeedLink(link);
+
+            Assert.False(actual);
+        }
+
+        [Theory, AutoAtomData]
         public void AppendAsyncCorrectlyStoresFeedAndEntry(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
             AtomEventStream<TestEventX> sut,

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -361,39 +361,6 @@ namespace Grean.AtomEventStore.UnitTests
                 previousPage.Links.Count(AtomEventStream.IsPreviousFeedLink));
         }
 
-        [Theory, AutoAtomData]
-        public void AppendAsyncCorrectlyLinksSecondChangesetToFirst(
-            [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
-            AtomEventStream<TestEventX> sut,
-            TestEventX event1,
-            TestEventX event2)
-        {
-            // Fixture setup
-
-            // Exercise system
-            sut.AppendAsync(event1).Wait();
-            sut.AppendAsync(event2).Wait();
-
-            // Verify outcome
-            var writtenFeed = storage.Feeds.Select(AtomFeed.Parse).Single();
-            var writtenEntries = storage.Entries.Select(AtomEntry.Parse);
-
-            var headLink = writtenFeed
-                .Entries.First()
-                .Links.FirstOrDefault(l => l.IsViaLink);
-            Assert.NotNull(headLink);
-            var head = writtenEntries.Single(
-                e => e.Links.Any(l => headLink.ToSelfLink().Equals(l)));
-            var previousLink = head.Links.SingleOrDefault(l => l.Rel == "previous");
-            Assert.NotNull(previousLink);
-            var previous = writtenEntries.Single(
-                e => e.Links.Any(l => previousLink.ToSelfLink().Equals(l)));
-            Assert.False(
-                previous.Links.Any(l => l.Rel == "previous"),
-                "First entry can't have a previous link.");
-            // Teardown
-        }
-
         private class AtomFeedLikeness
         {
             private readonly DateTimeOffset minimumTime;

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -110,34 +110,20 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void AppendAsyncCorrectlyStoresFeedAndEntry(
+        public void AppendAsyncCorrectlyStoresFeed(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
             AtomEventStream<TestEventX> sut,
             TestEventX expectedEvent)
         {
-            // Fixture setup
             var before = DateTimeOffset.Now;
 
-            // Exercise system
             sut.AppendAsync(expectedEvent).Wait();
 
-            // Verify outcome
             var writtenFeed = storage.Feeds.Select(AtomFeed.Parse).Single();
             var expectedFeed = new AtomFeedLikeness(before, sut.Id, expectedEvent);
             Assert.True(
                 expectedFeed.Equals(writtenFeed),
                 "Expected feed must match actual feed.");
-
-            var writtenEntry = storage.Entries.Select(AtomEntry.Parse).Single();
-            var expectedEntry = new AtomEntryLikeness(
-                before,
-                expectedEvent,
-                "self");
-            Assert.True(
-                expectedEntry.Equals(writtenEntry),
-                "Expected entry must match actual entry.");
-
-            // Teardown
         }
 
         [Theory, AutoAtomData]

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -35,12 +35,10 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void PageSizeIsCorrect(
-            [Frozen]int expected,
-            AtomEventStream<TestEventX> sut)
+        public void Test(Generator<AtomEventStream<TestEventX>> g)
         {
-            int actual = sut.PageSize;
-            Assert.Equal(expected, actual);
+            var pageSizes = g.Select(s => s.PageSize).Take(256);
+            Assert.NotEmpty(pageSizes.Where(i => i != 1));
         }
 
         [Theory, AutoAtomData]

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -553,6 +553,25 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
+        public void SutYieldsPagedEvents(
+            [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory dummyInjectedIntoSut,
+            AtomEventStream<TestEventX> sut,
+            Generator<TestEventX> eventGenerator)
+        {
+            var events = eventGenerator.Take(sut.PageSize * 2 + 1).ToList();
+
+            events.ForEach(e => sut.AppendAsync(e).Wait());
+
+            var expected = events.AsEnumerable().Reverse();
+            Assert.True(
+                expected.SequenceEqual(sut),
+                "Events should be yielded in a FILO order");
+            Assert.True(
+                expected.Cast<object>().SequenceEqual(sut.OfType<object>()),
+                "Events should be yielded in a FILO order");
+        }
+
+        [Theory, AutoAtomData]
         public void SutCanAppendAndYieldPolymorphicEvents(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory dummyInjectedIntoSut,
             AtomEventStream<ITestEvent> sut,

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -34,6 +34,15 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
+        public void PageSizeIsCorrect(
+            [Frozen]int expected,
+            AtomEventStream<TestEventX> sut)
+        {
+            int actual = sut.PageSize;
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory, AutoAtomData]
         public void CreateSelfLinkFromReturnsCorrectResult(
             UuidIri id)
         {

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -141,40 +141,23 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void AppendAsyncCorrectlyStoresFeedAndEntries(
+        public void AppendAsyncCorrectlyStoresFeeds(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
             AtomEventStream<TestEventX> sut,
             TestEventX event1,
             TestEventX event2)
         {
-            // Fixture setup
             var before = DateTimeOffset.Now;
 
-            // Exercise system
             sut.AppendAsync(event1).Wait();
             sut.AppendAsync(event2).Wait();
 
-            // Verify outcome
             var writtenFeed = storage.Feeds.Select(AtomFeed.Parse).Single();
-            var writtenEntries = storage.Entries.Select(AtomEntry.Parse);
-
             var expectedFeed =
                 new AtomFeedLikeness(before, sut.Id, event2, event1);
-            var expectedEntries = new HashSet<object>(
-                new[]
-                {
-                    new AtomEntryLikeness(before, event1, "self"),
-                    new AtomEntryLikeness(before, event2, "self")
-                },
-                new HashFreeEqualityComparer<object>());
-
             Assert.True(
                 expectedFeed.Equals(writtenFeed),
                 "Expected feed must match actual feed.");
-            Assert.True(
-                expectedEntries.SetEquals(writtenEntries),
-                "Expected entries must match actual entries.");
-            // Teardown
         }
 
         [Theory, AutoAtomData]

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -366,6 +366,33 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
+        public void AppendAsyncTwicePageSizeEventDoesNotAddPreviousLinkToPreviousPage(
+            [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
+            AtomEventStream<TestEventX> sut,
+            Generator<TestEventX> eventGenerator)
+        {
+            var before = DateTimeOffset.Now;
+            var events = eventGenerator.Take(sut.PageSize * 2).ToList();
+
+            events.ForEach(e => sut.AppendAsync(e).Wait());
+
+            var writtenIndex = storage.Feeds
+                .Select(AtomFeed.Parse)
+                .Single(f => f.Id == sut.Id);
+            UuidIri previousPageId =
+                Guid.Parse(
+                    writtenIndex.Links
+                        .Single(AtomEventStream.IsPreviousFeedLink)
+                        .Href.ToString());
+            var previousPage = storage.Feeds
+                .Select(AtomFeed.Parse)
+                .Single(f => f.Id == previousPageId);
+            Assert.Equal(
+                0,
+                previousPage.Links.Count(AtomEventStream.IsPreviousFeedLink));
+        }
+
+        [Theory, AutoAtomData]
         public void AppendAsyncCorrectlyLinksSecondChangesetToFirst(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
             AtomEventStream<TestEventX> sut,

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -243,6 +243,25 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
+        public void AppendAsyncLessThanPageSizeEventsDoesNotAddLinkToPreviousPageToIndex(
+            [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
+            AtomEventStream<TestEventX> sut,
+            Generator<TestEventX> eventGenerator)
+        {
+            var before = DateTimeOffset.Now;
+            var events = eventGenerator.Take(sut.PageSize).ToList();
+
+            events.ForEach(e => sut.AppendAsync(e).Wait());
+
+            var writtenIndex = storage.Feeds
+                .Select(AtomFeed.Parse)
+                .Single(f => f.Id == sut.Id);
+            Assert.Equal(
+                0,
+                writtenIndex.Links.Count(AtomEventStream.IsPreviousFeedLink));
+        }
+
+        [Theory, AutoAtomData]
         public void AppendAsyncCorrectlyLinksSecondChangesetToFirst(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
             AtomEventStream<TestEventX> sut,

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -224,6 +224,25 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
+        public void AppendAsyncMoreThenPageSizeEventsAddsLinkToPreviousPageToIndex(
+            [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
+            AtomEventStream<TestEventX> sut,
+            Generator<TestEventX> eventGenerator)
+        {
+            var before = DateTimeOffset.Now;
+            var events = eventGenerator.Take(sut.PageSize + 1).ToList();
+
+            events.ForEach(e => sut.AppendAsync(e).Wait());
+
+            var writtenIndex = storage.Feeds
+                .Select(AtomFeed.Parse)
+                .Single(f => f.Id == sut.Id);
+            Assert.Equal(
+                1,
+                writtenIndex.Links.Count(AtomEventStream.IsPreviousFeedLink));
+        }
+
+        [Theory, AutoAtomData]
         public void AppendAsyncCorrectlyLinksSecondChangesetToFirst(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
             AtomEventStream<TestEventX> sut,

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -57,6 +57,19 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
+        public void CreatePreviousLinkFromReturnsCorrectResult(
+            UuidIri id)
+        {
+            AtomLink actual = AtomEventStream.CreatePreviousLinkFrom(id);
+
+            var expected = AtomLink.CreatePreviousLink(
+                new Uri(
+                    ((Guid)id).ToString(),
+                    UriKind.Relative));
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory, AutoAtomData]
         public void AppendAsyncCorrectlyStoresFeedAndEntry(
             [Frozen(As = typeof(IAtomEventStorage))]AtomEventsInMemory storage,
             AtomEventStream<TestEventX> sut,

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -384,7 +384,7 @@ namespace Grean.AtomEventStore.UnitTests
                     return base.Equals(obj);
 
                 var expectedEntries = this.expectedEvents
-                    .Select(e => new AtomEntryLikeness(this.minimumTime, e, "via"))
+                    .Select(e => new AtomEntryLikeness(this.minimumTime, e))
                     .Cast<object>();
 
                 return object.Equals(this.expectedId, actual.Id)
@@ -406,16 +406,13 @@ namespace Grean.AtomEventStore.UnitTests
         {
             private readonly DateTimeOffset minimumTime;
             private readonly object expectedEvent;
-            private readonly string idRel;
 
             public AtomEntryLikeness(
                 DateTimeOffset minimumTime,
-                object expectedEvent,
-                string idRel)
+                object expectedEvent)
             {
                 this.minimumTime = minimumTime;
                 this.expectedEvent = expectedEvent;
-                this.idRel = idRel;
             }
 
             public override bool Equals(object obj)
@@ -430,10 +427,6 @@ namespace Grean.AtomEventStore.UnitTests
                     && actual.Published <= DateTimeOffset.Now
                     && this.minimumTime <= actual.Updated
                     && actual.Updated <= DateTimeOffset.Now
-                    && actual.Links.Contains(
-                        AtomEventStream
-                            .CreateSelfLinkFrom(actual.Id)
-                            .WithRel(this.idRel))
                     && object.Equals(this.expectedEvent, actual.Content.Item);
             }
 

--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -104,7 +104,8 @@ namespace Grean.AtomEventStore.UnitTests
             var writtenFeed = storage.Feeds.Select(AtomFeed.Parse).Single();
             var writtenEntries = storage.Entries.Select(AtomEntry.Parse);
 
-            var expectedFeed = new AtomFeedLikeness(before, sut.Id, event2);
+            var expectedFeed =
+                new AtomFeedLikeness(before, sut.Id, event2, event1);
             var expectedEntries = new HashSet<object>(
                 new[]
                 {
@@ -113,8 +114,12 @@ namespace Grean.AtomEventStore.UnitTests
                 },
                 new HashFreeEqualityComparer<object>());
 
-            Assert.True(expectedFeed.Equals(writtenFeed));
-            Assert.True(expectedEntries.SetEquals(writtenEntries));
+            Assert.True(
+                expectedFeed.Equals(writtenFeed),
+                "Expected feed must match actual feed.");
+            Assert.True(
+                expectedEntries.SetEquals(writtenEntries),
+                "Expected entries must match actual entries.");
             // Teardown
         }
 
@@ -344,12 +349,12 @@ namespace Grean.AtomEventStore.UnitTests
             [Frozen]Mock<IAtomEventStorage> storageMock,
             AtomEventStream<TestEventX> sut,
             TestEventX tex,
-            AtomFeed initialFeed)
+            AtomFeedBuilder<TestEventX> initialFeedBuilder)
         {
             // Fixture setup
             var stream = new MemoryStream();
             using (var xw = XmlWriter.Create(stream))
-                initialFeed.WriteTo(xw);
+                initialFeedBuilder.Build().WriteTo(xw);
             stream.Position = 0;
             storageMock
                 .Setup(s => s.CreateFeedReaderFor(It.IsAny<Uri>()))

--- a/AtomEventStore.UnitTests/AtomEventsInMemoryTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventsInMemoryTests.cs
@@ -12,80 +12,6 @@ namespace Grean.AtomEventStore.UnitTests
     public class AtomEventsInMemoryTests
     {
         [Theory, AutoAtomData]
-        public void ClientCanReadWrittenEntry(
-            AtomEventsInMemory sut,
-            AtomEntryBuilder<TestEventX> entry)
-        {
-            var expected = entry.Build();
-
-            using (var w = sut.CreateEntryWriterFor(expected))
-                expected.WriteTo(w);
-            using (var r = sut.CreateEntryReaderFor(expected.Locate()))
-            {
-                var actual = AtomEntry.ReadFrom(r);
-
-                Assert.Equal(expected, actual, new AtomEntryComparer());
-            }
-        }
-
-        [Theory, AutoAtomData]
-        public void ClientCanReadFirstEntry(
-            AtomEventsInMemory sut,
-            AtomEntryBuilder<TestEventX> entry1,
-            AtomEntryBuilder<TestEventY> entry2)
-        {
-            var expected = entry1.Build();
-            var other = entry2.Build();
-
-            using (var w = sut.CreateEntryWriterFor(expected))
-                expected.WriteTo(w);
-            using (var w = sut.CreateEntryWriterFor(other))
-                other.WriteTo(w);
-
-            using (var r = sut.CreateEntryReaderFor(expected.Locate()))
-            {
-                var actual = AtomEntry.ReadFrom(r);
-
-                Assert.Equal(expected, actual, new AtomEntryComparer());
-            }
-        }
-
-        [Theory, AutoAtomData]
-        public void ClientCanReadSecondEntry(
-            AtomEventsInMemory sut,
-            AtomEntryBuilder<TestEventX> entry1,
-            AtomEntryBuilder<TestEventY> entry2)
-        {
-            var other = entry1.Build();
-            var expected = entry2.Build();
-
-            using (var w = sut.CreateEntryWriterFor(other))
-                other.WriteTo(w);
-            using (var w = sut.CreateEntryWriterFor(expected))
-                expected.WriteTo(w);
-
-            using (var r = sut.CreateEntryReaderFor(expected.Locate()))
-            {
-                var actual = AtomEntry.ReadFrom(r);
-
-                Assert.Equal(expected, actual, new AtomEntryComparer());
-            }
-        }
-
-        [Theory, AutoAtomData]
-        public void ClientCannotRepeatedWriteSameEntry(
-            AtomEventsInMemory sut,
-            AtomEntryBuilder<TestEventX> entryBuilder)
-        {
-            var entry = entryBuilder.Build();
-            using (var w = sut.CreateEntryWriterFor(entry))
-                entry.WriteTo(w);
-
-            Assert.Throws<InvalidOperationException>(
-                () => sut.CreateEntryWriterFor(entry));
-        }
-
-        [Theory, AutoAtomData]
         public void ClientCanReadWrittenFeed(
             AtomEventsInMemory sut,
             AtomFeedBuilder<TestEventX> feedBuilder)
@@ -207,23 +133,6 @@ namespace Grean.AtomEventStore.UnitTests
             Assert.True(
                 expected.SetEquals(sut.Feeds),
                 "Written feeds should be enumerated.");
-        }
-
-        [Theory, AutoAtomData]
-        public void EntriesReturnWrittenEntries(
-            AtomEventsInMemory sut,
-            IEnumerable<AtomEntryBuilder<TestEventX>> entryBuilders)
-        {
-            var entries = entryBuilders.Select(b => b.Build());
-            foreach (var e in entries)
-                using (var w = sut.CreateEntryWriterFor(e))
-                    e.WriteTo(w);
-
-            var expected = new HashSet<string>(
-                entries.Select(w => w.ToXmlString()));
-            Assert.True(
-                expected.SetEquals(sut.Entries),
-                "Written entries should be enumerated.");
         }
     }
 }

--- a/AtomEventStore.UnitTests/AtomLinkTests.cs
+++ b/AtomEventStore.UnitTests/AtomLinkTests.cs
@@ -241,5 +241,44 @@ namespace Grean.AtomEventStore.UnitTests
             var expected = sut.WithRel("via");
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void CreatePreviousLinkReturnsCorrectResult(
+            AtomLink link)
+        {
+            AtomLink actual = AtomLink.CreatePreviousLink(link.Href);
+
+            var expected = link.WithRel("previous");
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory, AutoAtomData]
+        public void IsPreviousLinkReturnsTrueForPreviousLink(
+            Uri href)
+        {
+            bool actual = AtomLink.CreatePreviousLink(href).IsPreviousLink;
+            Assert.True(actual, "Should be previous link.");
+        }
+
+        [Theory, AutoAtomData]
+        public void IsPreviousLinkReturnsFalsForNonPreviousLink(
+            AtomLink sut)
+        {
+            Assert.NotEqual("previous", sut.Rel);
+            var actual = sut.IsPreviousLink;
+            Assert.False(actual, "Should not be previous link.");
+        }
+
+        [Theory, AutoAtomData]
+        public void ToPreviousLinkReturnsCorrectResult(
+            AtomLink sut)
+        {
+            Assert.NotEqual("previous", sut.Rel);
+
+            AtomLink actual = sut.ToPreviousLink();
+
+            var expected = sut.WithRel("previous");
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/AtomLinkTests.cs
+++ b/AtomEventStore.UnitTests/AtomLinkTests.cs
@@ -280,5 +280,44 @@ namespace Grean.AtomEventStore.UnitTests
             var expected = sut.WithRel("previous");
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void CreateNextLinkReturnsCorrectResult(
+            AtomLink link)
+        {
+            AtomLink actual = AtomLink.CreateNextLink(link.Href);
+
+            var expected = link.WithRel("next");
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory, AutoAtomData]
+        public void IsNextLinkReturnsTrueForNextLink(
+            Uri href)
+        {
+            bool actual = AtomLink.CreateNextLink(href).IsNextLink;
+            Assert.True(actual, "Should be next link.");
+        }
+
+        [Theory, AutoAtomData]
+        public void IsNextLinkReturnsFalsForNonNextLink(
+            AtomLink sut)
+        {
+            Assert.NotEqual("next", sut.Rel);
+            var actual = sut.IsNextLink;
+            Assert.False(actual, "Should not be next link.");
+        }
+
+        [Theory, AutoAtomData]
+        public void ToNextLinkReturnsCorrectResult(
+            AtomLink sut)
+        {
+            Assert.NotEqual("next", sut.Rel);
+
+            AtomLink actual = sut.ToNextLink();
+
+            var expected = sut.WithRel("next");
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/AutoAtomDataAttribute.cs
+++ b/AtomEventStore.UnitTests/AutoAtomDataAttribute.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.AutoMoq;
+using Ploeh.AutoFixture.Kernel;
 using Ploeh.AutoFixture.Xunit;
 
 namespace Grean.AtomEventStore.UnitTests
@@ -20,10 +22,35 @@ namespace Grean.AtomEventStore.UnitTests
         {
             public AtomEventsCustomization()
                 : base(
+                    new PageSizeCustomization(),
                     new DirectoryCustomization(),
                     new StreamCustomization(),
                     new AutoMoqCustomization())
             {
+            }
+
+            private class PageSizeCustomization : ICustomization
+            {
+                public void Customize(IFixture fixture)
+                {
+                    fixture.Customizations.Add(new PageSizeRelay());
+                }
+
+                private class PageSizeRelay : ISpecimenBuilder
+                {
+                    private readonly Random r = new Random();
+
+                    public object Create(object request, ISpecimenContext context)
+                    {
+                        var pi = request as ParameterInfo;
+                        if (pi == null ||
+                            pi.ParameterType != typeof(int) ||
+                            pi.Name != "pageSize")
+                            return new NoSpecimen(request);
+
+                        return this.r.Next(1, 17);
+                    }
+                }
             }
 
             private class DirectoryCustomization : ICustomization

--- a/AtomEventStore.UnitTests/SpyAtomEventStore.cs
+++ b/AtomEventStore.UnitTests/SpyAtomEventStore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Grean.AtomEventStore.UnitTests
+{
+    public class SpyAtomEventStore : IAtomEventStorage
+    {
+        private readonly IAtomEventStorage store;
+        private readonly List<object> observedArguments;
+
+        public SpyAtomEventStore()
+        {
+            this.store = new AtomEventsInMemory();
+            this.observedArguments = new List<object>();
+        }
+
+        public IEnumerable<object> ObservedArguments
+        {
+            get { return this.observedArguments; }
+        }
+
+        public XmlReader CreateEntryReaderFor(Uri href)
+        {
+            this.observedArguments.Add(href);
+            return this.store.CreateEntryReaderFor(href);
+        }
+
+        public XmlWriter CreateEntryWriterFor(AtomEntry atomEntry)
+        {
+            this.observedArguments.Add(atomEntry);
+            return this.store.CreateEntryWriterFor(atomEntry);
+        }
+
+        public XmlReader CreateFeedReaderFor(Uri href)
+        {
+            this.observedArguments.Add(href);
+            return this.store.CreateFeedReaderFor(href);
+        }
+
+        public XmlWriter CreateFeedWriterFor(AtomFeed atomFeed)
+        {
+            this.observedArguments.Add(atomFeed);
+            return this.store.CreateFeedWriterFor(atomFeed);
+        }
+    }
+}

--- a/AtomEventStore.UnitTests/SpyAtomEventStore.cs
+++ b/AtomEventStore.UnitTests/SpyAtomEventStore.cs
@@ -23,18 +23,6 @@ namespace Grean.AtomEventStore.UnitTests
             get { return this.observedArguments; }
         }
 
-        public XmlReader CreateEntryReaderFor(Uri href)
-        {
-            this.observedArguments.Add(href);
-            return this.store.CreateEntryReaderFor(href);
-        }
-
-        public XmlWriter CreateEntryWriterFor(AtomEntry atomEntry)
-        {
-            this.observedArguments.Add(atomEntry);
-            return this.store.CreateEntryWriterFor(atomEntry);
-        }
-
         public XmlReader CreateFeedReaderFor(Uri href)
         {
             this.observedArguments.Add(href);

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -176,7 +176,7 @@ namespace Grean.AtomEventStore
                         "Partial event stream",
                         now,
                         new AtomAuthor("Grean"),
-                        new AtomEntry[0],
+                        feed.Entries.Skip(1),
                         new[] { AtomEventStream.CreateSelfLinkFrom(previousFeedId) });
                     using (var w = this.storage.CreateFeedWriterFor(previousFeed))
                         previousFeed.WriteTo(w);

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -166,7 +166,7 @@ namespace Grean.AtomEventStore
                     now,
                     new AtomAuthor("Grean"),
                     new[] { entry.WithLinks(entry.Links.Select(ChangeRelFromSelfToVia)) }.Concat(index.Entries),
-                    new[] { CreateSelfLinkFrom(this.id) });
+                    new[] { AtomEventStream.CreateSelfLinkFrom(this.id), AtomEventStream.CreatePreviousLinkFrom(Guid.NewGuid()) });
 
                 if (feed.Entries.Count() > this.pageSize)
                     feed = feed.WithEntries(feed.Entries.Take(1));
@@ -195,7 +195,7 @@ namespace Grean.AtomEventStore
                     where l.IsViaLink
                     select l.WithRel("previous"))
                     .Take(1)
-                    .Concat(new[] { CreateSelfLinkFrom(changesetId) });
+                    .Concat(new[] { AtomEventStream.CreateSelfLinkFrom(changesetId) });
         }
 
         private static AtomLink ChangeRelFromSelfToVia(AtomLink link)
@@ -232,11 +232,6 @@ namespace Grean.AtomEventStore
         public int PageSize
         {
             get { return this.pageSize; }
-        }
-
-        private static AtomLink CreateSelfLinkFrom(Guid id)
-        {
-            return AtomEventStream.CreateSelfLinkFrom(id);
         }
 
         /// <summary>

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -177,7 +177,7 @@ namespace Grean.AtomEventStore
                         now,
                         new AtomAuthor("Grean"),
                         feed.Entries.Skip(1),
-                        new[] { AtomEventStream.CreateSelfLinkFrom(previousFeedId) });
+                        new[] { AtomEventStream.CreateSelfLinkFrom(previousFeedId), AtomEventStream.CreatePreviousLinkFrom(Guid.NewGuid()) });
                     using (var w = this.storage.CreateFeedWriterFor(previousFeed))
                         previousFeed.WriteTo(w);
 

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -56,6 +56,7 @@ namespace Grean.AtomEventStore
     {
         private readonly UuidIri id;
         private readonly IAtomEventStorage storage;
+        private readonly int pageSize;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AtomEventStream{T}" />
@@ -85,10 +86,12 @@ namespace Grean.AtomEventStore
         /// <seealso cref="IAtomEventStorage" />
         public AtomEventStream(
             UuidIri id,
-            IAtomEventStorage storage)
+            IAtomEventStorage storage,
+            int pageSize)
         {
             this.id = id;
             this.storage = storage;
+            this.pageSize = pageSize;
         }
 
         /// <summary>
@@ -221,6 +224,11 @@ namespace Grean.AtomEventStore
         public IAtomEventStorage Storage
         {
             get { return this.storage; }
+        }
+
+        public int PageSize
+        {
+            get { return this.pageSize; }
         }
 
         private static AtomLink CreateSelfLinkFrom(Guid id)

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -168,6 +168,9 @@ namespace Grean.AtomEventStore
                     new[] { entry.WithLinks(entry.Links.Select(ChangeRelFromSelfToVia)) }.Concat(index.Entries),
                     new[] { CreateSelfLinkFrom(this.id) });
 
+                if (feed.Entries.Count() > this.pageSize)
+                    feed = feed.WithEntries(feed.Entries.Take(1));
+
                 using (var w = this.storage.CreateEntryWriterFor(entry))
                     entry.WriteTo(w);
                 using (var w = this.storage.CreateFeedWriterFor(feed))

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -165,7 +165,7 @@ namespace Grean.AtomEventStore
                     "Index of event stream " + (Guid)this.id,
                     now,
                     new AtomAuthor("Grean"),
-                    new[] { entry.WithLinks(entry.Links.Select(ChangeRelFromSelfToVia)) },
+                    new[] { entry.WithLinks(entry.Links.Select(ChangeRelFromSelfToVia)) }.Concat(index.Entries),
                     new[] { CreateSelfLinkFrom(this.id) });
 
                 using (var w = this.storage.CreateEntryWriterFor(entry))
@@ -265,7 +265,7 @@ namespace Grean.AtomEventStore
         /// </remarks>
         public IEnumerator<T> GetEnumerator()
         {
-            var entry = this.ReadIndex().Entries.SingleOrDefault();
+            var entry = this.ReadIndex().Entries.FirstOrDefault();
             while (entry != null)
             {
                 yield return Cast(entry.Content.Item);

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -396,5 +396,11 @@ namespace Grean.AtomEventStore
             return AtomLink.CreateSelfLink(
                 new Uri(id.ToString(), UriKind.Relative));
         }
+
+        public static AtomLink CreatePreviousLinkFrom(Guid id)
+        {
+            return AtomLink.CreatePreviousLink(
+                new Uri(id.ToString(), UriKind.Relative));
+        }
     }
 }

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -186,8 +186,6 @@ namespace Grean.AtomEventStore
                         .WithLinks(feed.Links.Where(l => !AtomEventStream.IsPreviousFeedLink(l)).Concat(new[] { AtomEventStream.CreatePreviousLinkFrom(previousFeedId) }));
                 }
 
-                using (var w = this.storage.CreateEntryWriterFor(entry))
-                    entry.WriteTo(w);
                 using (var w = this.storage.CreateFeedWriterFor(feed))
                     feed.WriteTo(w);
             });

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -325,10 +325,12 @@ namespace Grean.AtomEventStore
             var page = this.ReadIndex();
             while (page != null)
             {
+                var t = Task.Factory.StartNew(() => this.GetPreviousPage(page));
+
                 foreach (var entry in page.Entries)
                     yield return Cast(entry.Content.Item);
 
-                page = this.GetPreviousPage(page);
+                page = t.Result;
             }
         }
 

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -402,5 +402,13 @@ namespace Grean.AtomEventStore
             return AtomLink.CreatePreviousLink(
                 new Uri(id.ToString(), UriKind.Relative));
         }
+
+        public static bool IsPreviousFeedLink(AtomLink link)
+        {
+            Guid g;
+            return link.IsPreviousLink
+                && !link.Href.IsAbsoluteUri
+                && Guid.TryParse(link.Href.ToString(), out g);
+        }
     }
 }

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -170,20 +170,30 @@ namespace Grean.AtomEventStore
 
                 if (feed.Entries.Count() > this.pageSize)
                 {
-                    var previousFeedId = UuidIri.NewId();
+                    var previousId = UuidIri.NewId();
                     var previousFeed = new AtomFeed(
-                        previousFeedId,
+                        previousId,
                         "Partial event stream",
                         now,
                         new AtomAuthor("Grean"),
                         feed.Entries.Skip(1),
-                        feed.Links.Where(AtomEventStream.IsPreviousFeedLink).Concat(new[] { AtomEventStream.CreateSelfLinkFrom(previousFeedId) }));
+                        feed.Links
+                            .Where(AtomEventStream.IsPreviousFeedLink)
+                            .Concat(new[]
+                            {
+                                AtomEventStream.CreateSelfLinkFrom(previousId) 
+                            }));
                     using (var w = this.storage.CreateFeedWriterFor(previousFeed))
                         previousFeed.WriteTo(w);
 
                     feed = feed
                         .WithEntries(feed.Entries.Take(1))
-                        .WithLinks(feed.Links.Where(l => !AtomEventStream.IsPreviousFeedLink(l)).Concat(new[] { AtomEventStream.CreatePreviousLinkFrom(previousFeedId) }));
+                        .WithLinks(feed.Links
+                            .Where(l => !AtomEventStream.IsPreviousFeedLink(l))
+                            .Concat(new[]
+                            {
+                                AtomEventStream.CreatePreviousLinkFrom(previousId)
+                            }));
                 }
 
                 using (var w = this.storage.CreateFeedWriterFor(feed))

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -158,14 +158,14 @@ namespace Grean.AtomEventStore
                     now,
                     new AtomAuthor("Grean"),
                     new XmlAtomContent(@event),
-                    CreateLinksForNewEntry(index, changesetId));
+                    new AtomLink[0]);
 
                 var feed = new AtomFeed(
                     this.id,
                     "Index of event stream " + (Guid)this.id,
                     now,
                     new AtomAuthor("Grean"),
-                    new[] { entry.WithLinks(entry.Links.Select(ChangeRelFromSelfToVia)) }.Concat(index.Entries),
+                    new[] { entry }.Concat(index.Entries),
                     index.Links);
 
                 if (feed.Entries.Count() > this.pageSize)
@@ -197,23 +197,6 @@ namespace Grean.AtomEventStore
                 new Uri(((Guid)this.id).ToString(), UriKind.Relative);
             using (var r = this.storage.CreateFeedReaderFor(indexAddress))
                 return AtomFeed.ReadFrom(r);
-        }
-
-        private static IEnumerable<AtomLink> CreateLinksForNewEntry(
-            AtomFeed index,
-            Guid changesetId)
-        {
-            return (from e in index.Entries
-                    from l in e.Links
-                    where l.IsViaLink
-                    select l.WithRel("previous"))
-                    .Take(1)
-                    .Concat(new[] { AtomEventStream.CreateSelfLinkFrom(changesetId) });
-        }
-
-        private static AtomLink ChangeRelFromSelfToVia(AtomLink link)
-        {
-            return link.IsSelfLink ? link.ToViaLink() : link;
         }
 
         /// <summary>

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -416,6 +416,9 @@ namespace Grean.AtomEventStore
 
         public static bool IsPreviousFeedLink(AtomLink link)
         {
+            if (link == null)
+                throw new ArgumentNullException("link");
+
             Guid g;
             return link.IsPreviousLink
                 && !link.Href.IsAbsoluteUri

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -70,6 +70,10 @@ namespace Grean.AtomEventStore
         /// <param name="storage">
         /// The underlying storage mechanism to use.
         /// </param>
+        /// <param name="pageSize">
+        /// The maxkum page size; that is: the maximum number of instances of
+        /// T stored in a single Atom feed page.
+        /// </param>
         /// <remarks>
         /// <para>
         /// The <paramref name="id" /> is the ID of a single event stream. Each
@@ -275,7 +279,7 @@ namespace Grean.AtomEventStore
         /// The id of the event stream, as originally supplied via the
         /// constructor.
         /// </value>
-        /// <seealso cref="AtomEventStream{T}(UuidIri, IAtomEventStorage)" />
+        /// <seealso cref="AtomEventStream{T}(UuidIri, IAtomEventStorage, int)" />
         public UuidIri Id
         {
             get { return this.id; }
@@ -288,7 +292,7 @@ namespace Grean.AtomEventStore
         /// The underlying storage mechanism, as originally supplied via the
         /// constructor.
         /// </value>
-        /// <seealso cref="AtomEventStream{T}(UuidIri, IAtomEventStorage)" />
+        /// <seealso cref="AtomEventStream{T}(UuidIri, IAtomEventStorage, int)" />
         public IAtomEventStorage Storage
         {
             get { return this.storage; }
@@ -299,10 +303,11 @@ namespace Grean.AtomEventStore
         /// </summary>
         /// <value>
         /// The maximum page size, measured in numbers of entries per Atom feed
-        /// page.
+        /// page. This value is supplied via the constructor.
         /// </value>
+        /// <seealso cref="AtomEventStream{T}(UuidIri, IAtomEventStorage, int)" />
         /// <seealso cref="AtomEventStream{T}" />
-        /// <seealso cref="AppendAsync{T}" />
+        /// <seealso cref="AppendAsync(T)" />
         public int PageSize
         {
             get { return this.pageSize; }

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -166,10 +166,12 @@ namespace Grean.AtomEventStore
                     now,
                     new AtomAuthor("Grean"),
                     new[] { entry.WithLinks(entry.Links.Select(ChangeRelFromSelfToVia)) }.Concat(index.Entries),
-                    new[] { AtomEventStream.CreateSelfLinkFrom(this.id), AtomEventStream.CreatePreviousLinkFrom(Guid.NewGuid()) });
+                    new[] { AtomEventStream.CreateSelfLinkFrom(this.id) });
 
                 if (feed.Entries.Count() > this.pageSize)
-                    feed = feed.WithEntries(feed.Entries.Take(1));
+                    feed = feed
+                        .WithEntries(feed.Entries.Take(1))
+                        .WithLinks(feed.Links.Concat(new[] { AtomEventStream.CreatePreviousLinkFrom(Guid.NewGuid()) }));
 
                 using (var w = this.storage.CreateEntryWriterFor(entry))
                     entry.WriteTo(w);

--- a/AtomEventStore/AtomEventsInFiles.cs
+++ b/AtomEventStore/AtomEventsInFiles.cs
@@ -19,24 +19,6 @@ namespace Grean.AtomEventStore
             this.directory = directory;
         }
 
-        public XmlReader CreateEntryReaderFor(Uri href)
-        {
-            if (href == null)
-                throw new ArgumentNullException("href");
-
-            var fileName = this.CreateFileName(href);
-            return XmlReader.Create(fileName);
-        }
-
-        public XmlWriter CreateEntryWriterFor(AtomEntry atomEntry)
-        {
-            if (atomEntry == null)
-                throw new ArgumentNullException("atomEntry");
-
-            var fileName = this.CreateFileName(atomEntry.Links);
-            return XmlWriter.Create(fileName);
-        }
-
         public XmlReader CreateFeedReaderFor(Uri href)
         {
             if (href == null)

--- a/AtomEventStore/AtomEventsInMemory.cs
+++ b/AtomEventStore/AtomEventsInMemory.cs
@@ -19,31 +19,6 @@ namespace Grean.AtomEventStore
             this.entries = new Dictionary<Uri, StringBuilder>();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AtomEntry", Justification = "This is a bug in the Code Analysis rule: http://bit.ly/17M7Jom")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "XmlWriter", Justification = "This is a bug in the Code Analysis rule: http://bit.ly/17M7Jom")]
-        public XmlWriter CreateEntryWriterFor(AtomEntry atomEntry)
-        {
-            if (atomEntry == null)
-                throw new ArgumentNullException("atomEntry");
-
-            var href = GetHrefFrom(atomEntry.Links);
-            if (this.entries.ContainsKey(href))
-                throw new InvalidOperationException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        "Will not create a new XmlWriter for the supplied AtomEntry, because a an AtomEntry with the ID {0} was already written.",
-                        href.ToString()));
-
-            var sb = new StringBuilder();
-            this.entries.Add(href, sb);
-            return XmlWriter.Create(sb);
-        }
-
-        public XmlReader CreateEntryReaderFor(Uri href)
-        {
-            return CreateReaderOver(this.entries[href].ToString());
-        }
-
         public XmlWriter CreateFeedWriterFor(AtomFeed atomFeed)
         {
             if (atomFeed == null)

--- a/AtomEventStore/AtomLink.cs
+++ b/AtomEventStore/AtomLink.cs
@@ -139,9 +139,6 @@ namespace Grean.AtomEventStore
 
         public static AtomLink CreatePreviousLink(Uri uri)
         {
-            if (uri == null)
-                throw new ArgumentNullException("uri");
-
             return new AtomLink("previous", uri);
         }
 
@@ -153,6 +150,21 @@ namespace Grean.AtomEventStore
         public AtomLink ToPreviousLink()
         {
             return this.WithRel("previous");
+        }
+
+        public static AtomLink CreateNextLink(Uri uri)
+        {
+            return new AtomLink("next", uri);
+        }
+
+        public bool IsNextLink
+        {
+            get { return this.rel == "next"; }
+        }
+
+        public AtomLink ToNextLink()
+        {
+            return this.WithRel("next");
         }
     }
 }

--- a/AtomEventStore/AtomLink.cs
+++ b/AtomEventStore/AtomLink.cs
@@ -136,5 +136,23 @@ namespace Grean.AtomEventStore
         {
             return this.WithRel("via");
         }
+
+        public static AtomLink CreatePreviousLink(Uri uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException("uri");
+
+            return new AtomLink("previous", uri);
+        }
+
+        public bool IsPreviousLink
+        {
+            get { return this.rel == "previous"; }
+        }
+
+        public AtomLink ToPreviousLink()
+        {
+            return this.WithRel("previous");
+        }
     }
 }

--- a/AtomEventStore/IAtomEventStorage.cs
+++ b/AtomEventStore/IAtomEventStorage.cs
@@ -30,61 +30,6 @@ namespace Grean.AtomEventStore
     public interface IAtomEventStorage
     {
         /// <summary>
-        /// Creates an <see cref="XmlReader" /> for reading an Atom entry from
-        /// the provided <see cref="Uri" />.
-        /// </summary>
-        /// <param name="href">
-        /// The relative <see cref="Uri" /> of the Atom entry to read.
-        /// </param>
-        /// <returns>
-        /// An <see cref="XmlReader" /> over the Atom entry identified by
-        /// <paramref name="href" />.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// <strong>Note to implementers:</strong>
-        /// </para>
-        /// <para>
-        /// If no entry can be found for <paramref name="href" />, the method
-        /// must throw an appropriate exception. Returning
-        /// <see langword="null" /> is considered an incorrect implementation.
-        /// </para>
-        /// </remarks>
-        XmlReader CreateEntryReaderFor(Uri href);
-
-        /// <summary>
-        /// Creates an <see cref="XmlWriter" /> for writing the provided
-        /// <see cref="AtomEntry" />.
-        /// </summary>
-        /// <param name="atomEntry">The Atom entry to write.</param>
-        /// <returns>
-        /// An <see cref="XmlWriter" /> over the Atom entry provided by
-        /// <paramref name="atomEntry" />.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// <strong>Note to implementers:</strong>
-        /// </para>
-        /// <para>
-        /// The implementation is free to choose an appropriate naming or
-        /// identification scheme that fits the underlying persistence
-        /// technology. However, it must be able to find the written Atom entry
-        /// when a client subsequently invokes
-        /// <see cref="CreateEntryReaderFor" />.
-        /// </para>
-        /// <para>
-        /// When the CreateEntryWriterFor method is invoked,
-        /// <paramref name="atomEntry" /> contains at least a 'self' link
-        /// (identified by <see cref="AtomLink.IsSelfLink" />) identifying the
-        /// Atom entry. The <see cref="AtomLink.Href" /> value of this link is
-        /// the value used when CreateEntryReaderFor is subsequently invoked to
-        /// read the Atom entry. In other words, this is the corrolation ID,
-        /// so a naming or identification scheme must take this into account.
-        /// </para>
-        /// </remarks>
-        XmlWriter CreateEntryWriterFor(AtomEntry atomEntry);
-
-        /// <summary>
         /// Creates an <see cref="XmlReader" /> for reading an Atom feed from
         /// the provided <see cref="Uri" />.
         /// </summary>


### PR DESCRIPTION
This, rather big refactoring(?) changes how the underlying storage model works. Instead of using myriads of small files (one for each Atom entry), it instead uses paged Atom feeds for chunkier access. Performance measurements (see attached images) indicate that a significant performance improvement can be gained on the read side, possibly at the cost of increased write time.

In the following graph we see that the download times significantly drop when using paged feeds instead of individual entries. However, we also see that upload times increase. The graph is a bit misleading because I have no data for the upload time for individual entries, so while it looks like the upload time explodes (from so-small-it's-not-even-visible-in-the-graph to several minutes) going from individual entries to paged feeds, this isn't necessarily the case. There's simply no data for that scenario.

![image](https://f.cloud.github.com/assets/242165/782030/f116fcee-ea33-11e2-904a-d6c3e9c160a4.png)

The big numbers for uploads mask the difference in page sizes for download times, so the next graph shows only the download times for various page sizes. For each page size, download time with and without pre-fetching is compared. It shows a significant improvement when pre-fetching is enabled, so this feature is part of this pull request.

![image](https://f.cloud.github.com/assets/242165/782122/69aae4f8-ea35-11e2-8611-a1b88215547a.png)

The final graph compares the size of the stored events. As we can see, the only significant difference is that moving from individual entry files to paged files noticeably reduces the size on disk. However, this measurement was made on my local file system, so it may be different on e.g. Windows Azure Blob Storage.

![image](https://f.cloud.github.com/assets/242165/782133/c4ea2a2c-ea35-11e2-8b4f-050722c369df.png)

All measurements were made from my local Lenovo X1 Carbon laptop in Copenhagen, Denmark against Windows Azure Blob Storage in Western Europe. The pre-fetching feature introduces a degree of parallelism, so results may vary based on the number of processors available to the client.
