### PR TITLE
Removed a bogus test

### DIFF
--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -35,13 +35,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void Test(Generator<AtomEventStream<TestEventX>> g)
-        {
-            var pageSizes = g.Select(s => s.PageSize).Take(256);
-            Assert.NotEmpty(pageSizes.Where(i => i != 1));
-        }
-
-        [Theory, AutoAtomData]
         public void CreateSelfLinkFromReturnsCorrectResult(
             UuidIri id)
         {


### PR DESCRIPTION
that should never have been committed. This test was just a sanity check I
wrote while troubleshooting an erratic test. It was never intended to be
checked in, but as sometimes happens, I forgot to remove it before
checking in a commit.
