### PR TITLE
Move responsibility for reading content

### DIFF
--- a/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
+++ b/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="AtomEntryComparer.cs" />
     <Compile Include="AtomEntryTests.cs" />
     <Compile Include="AtomEnvy.cs" />
+    <Compile Include="AtomEventsCustomization.cs" />
     <Compile Include="AtomEventsInFilesTests.cs" />
     <Compile Include="AtomFeedBuilder.cs" />
     <Compile Include="AtomFeedComparer.cs" />

--- a/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
+++ b/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="AtomEventStreamTests.cs" />
     <Compile Include="Changeset.cs" />
     <Compile Include="Conventions.cs" />
+    <Compile Include="InlineAutoAtomDataAttribute.cs" />
     <Compile Include="TestEventSealed.cs" />
     <Compile Include="Envelope.cs" />
     <Compile Include="EnvelopeTypeConverter.cs" />

--- a/AtomEventStore.UnitTests/AtomEventsCustomization.cs
+++ b/AtomEventStore.UnitTests/AtomEventsCustomization.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoMoq;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Grean.AtomEventStore.UnitTests
+{
+    public class AtomEventsCustomization : CompositeCustomization
+    {
+        public AtomEventsCustomization()
+            : base(
+                new PageSizeCustomization(),
+                new ContentSerializerCustomization(),
+                new DirectoryCustomization(),
+                new StreamCustomization(),
+                new AutoMoqCustomization())
+        {
+        }
+
+        private class PageSizeCustomization : ICustomization
+        {
+            public void Customize(IFixture fixture)
+            {
+                fixture.Customizations.Add(new PageSizeRelay());
+            }
+
+            private class PageSizeRelay : ISpecimenBuilder
+            {
+                private readonly Random r = new Random();
+
+                public object Create(object request, ISpecimenContext context)
+                {
+                    var pi = request as ParameterInfo;
+                    if (pi == null ||
+                        pi.ParameterType != typeof(int) ||
+                        pi.Name != "pageSize")
+                        return new NoSpecimen(request);
+
+                    return this.r.Next(2, 17);
+                }
+            }
+        }
+
+        private class ContentSerializerCustomization : ICustomization
+        {
+            public void Customize(IFixture fixture)
+            {
+                fixture.Customizations.Add(
+                    new TypeRelay(
+                        typeof(IContentSerializer),
+                        typeof(ConventionBasedSerializerOfComplexImmutableClasses)));
+            }
+        }
+
+        private class DirectoryCustomization : ICustomization
+        {
+            public void Customize(IFixture fixture)
+            {
+                fixture.Inject(
+                    new DirectoryInfo(Environment.CurrentDirectory));
+            }
+        }
+
+        private class StreamCustomization : ICustomization
+        {
+            public void Customize(IFixture fixture)
+            {
+                fixture.Register<Stream>(
+                    () => new MemoryStream());
+            }
+        }
+    }
+}

--- a/AtomEventStore.UnitTests/AutoAtomDataAttribute.cs
+++ b/AtomEventStore.UnitTests/AutoAtomDataAttribute.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using Ploeh.AutoFixture;
-using Ploeh.AutoFixture.AutoMoq;
-using Ploeh.AutoFixture.Kernel;
+﻿using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Xunit;
 
 namespace Grean.AtomEventStore.UnitTests
@@ -16,72 +8,6 @@ namespace Grean.AtomEventStore.UnitTests
         public AutoAtomDataAttribute()
             : base(new Fixture().Customize(new AtomEventsCustomization()))
         {
-        }
-
-        private class AtomEventsCustomization : CompositeCustomization
-        {
-            public AtomEventsCustomization()
-                : base(
-                    new PageSizeCustomization(),
-                    new ContentSerializerCustomization(),
-                    new DirectoryCustomization(),
-                    new StreamCustomization(),
-                    new AutoMoqCustomization())
-            {
-            }
-
-            private class PageSizeCustomization : ICustomization
-            {
-                public void Customize(IFixture fixture)
-                {
-                    fixture.Customizations.Add(new PageSizeRelay());
-                }
-
-                private class PageSizeRelay : ISpecimenBuilder
-                {
-                    private readonly Random r = new Random();
-
-                    public object Create(object request, ISpecimenContext context)
-                    {
-                        var pi = request as ParameterInfo;
-                        if (pi == null ||
-                            pi.ParameterType != typeof(int) ||
-                            pi.Name != "pageSize")
-                            return new NoSpecimen(request);
-
-                        return this.r.Next(2, 17);
-                    }
-                }
-            }
-
-            private class ContentSerializerCustomization : ICustomization
-            {
-                public void Customize(IFixture fixture)
-                {
-                    fixture.Customizations.Add(
-                        new TypeRelay(
-                            typeof(IContentSerializer),
-                            typeof(ConventionBasedSerializerOfComplexImmutableClasses)));
-                }
-            }
-
-            private class DirectoryCustomization : ICustomization
-            {
-                public void Customize(IFixture fixture)
-                {
-                    fixture.Inject(
-                        new DirectoryInfo(Environment.CurrentDirectory));
-                }
-            }
-
-            private class StreamCustomization : ICustomization
-            {
-                public void Customize(IFixture fixture)
-                {
-                    fixture.Register<Stream>(
-                        () => new MemoryStream());
-                }
-            }
         }
     }
 }

--- a/AtomEventStore.UnitTests/InlineAutoAtomDataAttribute.cs
+++ b/AtomEventStore.UnitTests/InlineAutoAtomDataAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Ploeh.AutoFixture.Xunit;
+
+namespace Grean.AtomEventStore.UnitTests
+{
+    public class InlineAutoAtomDataAttribute : InlineAutoDataAttribute
+    {
+        public InlineAutoAtomDataAttribute(params object[] values)
+            : base(new AutoAtomDataAttribute(), values)
+        {
+        }
+    }
+}

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -543,5 +543,33 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineAutoAtomData("<Content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">", "</Content>")]
+        [InlineAutoAtomData("<foo type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">", "</foo>")]
+        [InlineAutoAtomData("<content xmlns=\"http://www.w3.org/2005/Atom\">", "</content>")]
+        [InlineAutoAtomData("<content type=\"Application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">", "</content>")]
+        [InlineAutoAtomData("<content type=\"application/json\" xmlns=\"http://www.w3.org/2005/Atom\">", "</content>")]
+        [InlineAutoAtomData("<content type=\"text/xml\" xmlns=\"http://www.w3.org/2005/Atom\">", "</content>")]
+        [InlineAutoAtomData("<content type=\"bar\" xmlns=\"http://www.w3.org/2005/Atom\">", "</content>")]
+        [InlineAutoAtomData("<content type=\"application/xml\" xmlns=\"baz\">", "</content>")]
+        [InlineAutoAtomData("<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/ATOM\">", "</content>")]
+        public void ParseThrowsOnWrongContainingElement(
+            string startElement,
+            string endElement,
+            IContentSerializer dummySerializer)
+        {
+            var xml =
+                startElement +
+                "  <test-event-x xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <number>42</number>" +
+                "    <text>Foo</text>" +
+                "  </test-event-x>" +
+                endElement;
+            Assert.Throws<ArgumentException>(
+                () => XmlAtomContent.Parse(
+                    xml, 
+                    dummySerializer));
+        }
     }
 }

--- a/AtomEventStore/ConventionBasedSerializerOfComplexImmutableClasses.cs
+++ b/AtomEventStore/ConventionBasedSerializerOfComplexImmutableClasses.cs
@@ -113,9 +113,8 @@ namespace Grean.AtomEventStore
             if (xmlReader == null)
                 throw new ArgumentNullException("xmlReader");
 
-            xmlReader.MoveToContent();
             var x = (XElement)XElement.ReadFrom(xmlReader);
-            var item = ReadFrom(x.Elements().Single());
+            var item = ReadFrom(x);
             return new XmlAtomContent(item);
         }
 

--- a/AtomEventStore/XmlAtomContent.cs
+++ b/AtomEventStore/XmlAtomContent.cs
@@ -99,6 +99,9 @@ namespace Grean.AtomEventStore
             if (serializer == null)
                 throw new ArgumentNullException("serializer");
 
+            xmlReader.MoveToContent();
+            xmlReader.Read(); // TODO: Check if this is actually the 'content' node
+
             return serializer.Deserialize(xmlReader);
         }
     }

--- a/AtomEventStore/XmlAtomContent.cs
+++ b/AtomEventStore/XmlAtomContent.cs
@@ -98,11 +98,43 @@ namespace Grean.AtomEventStore
                 throw new ArgumentNullException("xmlReader");
             if (serializer == null)
                 throw new ArgumentNullException("serializer");
+            GuardContentElement(xmlReader);
 
-            xmlReader.MoveToContent();
-            xmlReader.Read(); // TODO: Check if this is actually the 'content' node
+            xmlReader.Read();
 
             return serializer.Deserialize(xmlReader);
+        }
+
+        private static void GuardContentElement(XmlReader xmlReader)
+        {
+            xmlReader.MoveToContent();
+
+            if (xmlReader.LocalName != "content")
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "The containing XML element of an Atom XML content entry must have the local name \"content\", but the name was \"{0}\". The name comparison is case-sensitive.",
+                        xmlReader.LocalName),
+                    "xmlReader");
+            if (xmlReader.NamespaceURI != "http://www.w3.org/2005/Atom")
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "The containing XML element of an Atom XML content entry must have the XML namespace \"http://www.w3.org/2005/Atom\", but the XML namespace was \"{0}\". The namespace comparison is case-sensitive.",
+                        xmlReader.NamespaceURI),
+                    "xmlReader");
+
+            if (!xmlReader.MoveToAttribute("type"))
+                throw new ArgumentException(
+                    "The containing XML element of an Atom XML content entry must have a \"type\" attribute, but none was found. The attribute name comparison is case-sensitive.",
+                    "xmlReader");
+            if (xmlReader.Value != "application/xml")
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "The containing XML element of an Atom XML content entry must have a \"type\" attribute with the value \"application/xml\", but the value was \"{0}\". The value comparison is case-sensitive.",
+                        xmlReader.Value),
+                    "xmlReader");
         }
     }
 }


### PR DESCRIPTION
in order to make XmlAtomContent's write and read operations
symmetric; XmlAtomContent.WriteTo already takes care of writing the
<content> element, so it should also take care of reading it, instead of
pushing that responsibility to each implementation of IContentSerializer.
