### PR TITLE
Removed unused class field from AtomEventsInMemory

### DIFF
--- a/AtomEventStore.UnitTests/AtomEventsInMemoryTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventsInMemoryTests.cs
@@ -130,13 +130,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void EntriesAreInitiallyEmpty(AtomEventsInMemory sut)
-        {
-            IEnumerable<string> actual = sut.Entries;
-            Assert.Empty(actual);
-        }
-
-        [Theory, AutoAtomData]
         public void FeedsReturnWrittenFeeds(
             AtomEventsInMemory sut,
             IEnumerable<AtomFeedBuilder<TestEventY>> feedBuilders)

--- a/AtomEventStore/AtomEventsInMemory.cs
+++ b/AtomEventStore/AtomEventsInMemory.cs
@@ -11,12 +11,10 @@ namespace Grean.AtomEventStore
     public class AtomEventsInMemory : IAtomEventStorage
     {
         private readonly Dictionary<Uri, StringBuilder> feeds;
-        private readonly Dictionary<Uri, StringBuilder> entries;
 
         public AtomEventsInMemory()
         {
             this.feeds = new Dictionary<Uri, StringBuilder>();
-            this.entries = new Dictionary<Uri, StringBuilder>();
         }
 
         public XmlWriter CreateFeedWriterFor(AtomFeed atomFeed)
@@ -85,14 +83,6 @@ namespace Grean.AtomEventStore
             get
             {
                 return this.feeds.Values.Select(sb => sb.ToString());
-            }
-        }
-
-        public IEnumerable<string> Entries
-        {
-            get
-            {
-                return this.entries.Values.Select(sb => sb.ToString());
             }
         }
     }


### PR DESCRIPTION
since no clients used it, apart from a single unit test. This is a remnant
from an earlier API change, back when events were stored as individual
entries instead of feed pages.
