### PR TITLE
Incremented minor version,

### DIFF
--- a/AtomEventStore.AzureBlob/Properties/AssemblyInfo.cs
+++ b/AtomEventStore.AzureBlob/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]
 
 [assembly: CLSCompliant(true)]

--- a/AtomEventStore.UnitTests/Properties/AssemblyInfo.cs
+++ b/AtomEventStore.UnitTests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]

--- a/AtomEventStore/Properties/AssemblyInfo.cs
+++ b/AtomEventStore/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]
 
 [assembly: CLSCompliant(true)]


### PR DESCRIPTION
in order to indicate that the introduction of the IContentSerializer and
the XmlContentSerializer class is most definitely a new feature. Actually,
the addition of IContentSerializer to the constructor of AtomEventStream
is a breaking change, but according to Semantic Versioning 2.0.0, since
AtomEventStore is still in the major version 0 range, anything can change
without further notice.

The reason for incrementing the version now is that, based on discussions today with Mikkel Christensen, parts of this library faces a largish refactoring, and I think it's a good idea to have a 'released' version before this work starts.
