### PR TITLE
Removed the filter of generic types

### DIFF
--- a/AtomEventStore.UnitTests/AtomEventStreamTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventStreamTests.cs
@@ -11,11 +11,21 @@ using Moq;
 using System.Xml;
 using System.IO;
 using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Idioms;
+using Ploeh.Albedo;
 
 namespace Grean.AtomEventStore.UnitTests
 {
     public class AtomEventStreamTests
     {
+        [Theory, AutoAtomData]
+        public void VerifyGuardClauses(GuardClauseAssertion assertion)
+        {
+            assertion.Verify(
+                typeof(AtomEventStream<TestEventX>).GetMembers()
+                    .Where(m => new Methods<AtomEventStream<TestEventX>>().Select(x => x.OnError(null)) != m));
+        }
+
         [Theory, AutoAtomData]
         public void IdIsCorrect(
             [Frozen]UuidIri expected,

--- a/AtomEventStore.UnitTests/Conventions.cs
+++ b/AtomEventStore.UnitTests/Conventions.cs
@@ -26,10 +26,10 @@ namespace Grean.AtomEventStore.UnitTests
         private static bool Include(Type t)
         {
             return !t.IsInterface
-                && !t.IsGenericTypeDefinition
                 && !IsStatic(t)
-                && t != typeof(AtomLink)    // Covered by AtomLinkTests
-                && t != typeof(AtomAuthor); // Covered by AtomAuthorTests
+                && t != typeof(AtomLink)           // Covered by AtomLinkTests
+                && t != typeof(AtomAuthor)         // Covered by AtomAuthorTests
+                && t != typeof(AtomEventStream<>); // Covered by AtomEventStreamTests
         }
 
         private static bool IsStatic(Type t)

--- a/AtomEventStore/AtomEventStream.cs
+++ b/AtomEventStore/AtomEventStream.cs
@@ -106,6 +106,11 @@ namespace Grean.AtomEventStore
             int pageSize,
             IContentSerializer contentSerializer)
         {
+            if (storage == null)
+                throw new ArgumentNullException("storage");
+            if (contentSerializer == null)
+                throw new ArgumentNullException("contentSerializer");
+            
             this.id = id;
             this.storage = storage;
             this.pageSize = pageSize;
@@ -164,6 +169,9 @@ namespace Grean.AtomEventStore
         /// </remarks>
         public Task AppendAsync(T @event)
         {
+            if (@event == null)
+                throw new ArgumentNullException("@event");
+
             return Task.Factory.StartNew(() =>
             {
                 var now = DateTimeOffset.Now;


### PR DESCRIPTION
from the convention-based test for Guard Clauses, since the current
version of AutoFixture.Idioms now handles open generics.
