### PR TITLE
Demonstrate use of discriminated union with data contract serializer

### DIFF
--- a/AtomEventStore.UnitTests.FSharp/AtomEventStore.UnitTests.FSharp.fsproj
+++ b/AtomEventStore.UnitTests.FSharp/AtomEventStore.UnitTests.FSharp.fsproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <Compile Include="Records.fs" />
     <Compile Include="TestDsl.fs" />
-    <Compile Include="AtomEventStreamFacadeTests.fs" />
+    <Compile Include="XmlEventStreamFacadeTests.fs" />
     <None Include="packages.config" />
     <None Include="app.config" />
   </ItemGroup>

--- a/AtomEventStore.UnitTests.FSharp/AtomEventStore.UnitTests.FSharp.fsproj
+++ b/AtomEventStore.UnitTests.FSharp/AtomEventStore.UnitTests.FSharp.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="Records.fs" />
     <Compile Include="TestDsl.fs" />
     <Compile Include="XmlEventStreamFacadeTests.fs" />
+    <Compile Include="DataContractEventsFacadeTests.fs" />
     <None Include="packages.config" />
     <None Include="app.config" />
   </ItemGroup>
@@ -87,6 +88,7 @@
       <HintPath>..\packages\Rx-Linq.2.2.2\lib\net45\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="Unquote">
       <HintPath>..\packages\Unquote.2.2.2\lib\net40\Unquote.dll</HintPath>

--- a/AtomEventStore.UnitTests.FSharp/AtomEventStreamFacadeTests.fs
+++ b/AtomEventStore.UnitTests.FSharp/AtomEventStreamFacadeTests.fs
@@ -10,7 +10,7 @@ open Xunit.Extensions
 
 module AtomEventStreamFacadeTests =
 
-    [<Theory; InMemoryConventions>]
+    [<Theory; InMemoryXmlConventions>]
     let SutCorrectlyRoundTripsASingleElement
         (sut : AtomEventStream<TestEventF>)
         (tef : TestEventF) =
@@ -20,7 +20,7 @@ module AtomEventStreamFacadeTests =
 
         Verify <@ actual.Length = 1 @>
 
-    [<Theory; InMemoryConventions>]
+    [<Theory; InMemoryXmlConventions>]
     let SutCorrectlyRoundTripsMultipleElements
         (sut : AtomEventStream<TestEventF>)
         (g : Generator<TestEventF>) =
@@ -33,7 +33,7 @@ module AtomEventStreamFacadeTests =
         let expected = tefs |> List.rev
         Verify <@ expected = actual @>
 
-    [<Theory; InMemoryConventions>]
+    [<Theory; InMemoryXmlConventions>]
     let SutCorrectlyRoundTripsDiscriminatedUnions
         (sut : AtomEventStream<obj>)
         (tef : TestEventF)
@@ -57,7 +57,7 @@ module AtomEventStreamFacadeTests =
         let expected = [teg |> G; tef |> F]
         Verify <@ expected = actual @>
 
-    [<Theory; InMemoryConventions>]
+    [<Theory; InMemoryXmlConventions>]
     let SutCorrectlyRoundTripsChangesetOfDiscriminatedUnions
         (sut : AtomEventStream<SerializableChangeset>)
         (tef : TestEventF)

--- a/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
+++ b/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
@@ -3,6 +3,7 @@
 open Grean.AtomEventStore
 open Grean.AtomEventStore.UnitTests.FSharp.DataContractRecords
 open Grean.AtomEventStore.UnitTests.FSharp.TestDsl
+open Ploeh.AutoFixture
 open Xunit.Extensions
 
 [<Theory; InMemoryDataContractConventions>]
@@ -16,3 +17,17 @@ let SutCorrectlyRoundTripsASingleElement
 
     Verify <@ actual.Length = 1 @>
     Verify <@ actual |> Seq.exactlyOne = tef @>
+
+[<Theory; InMemoryDataContractConventions>]
+let SutCorrectlyRoundTripsMultipleElements
+    (writer : AtomEventObserver<TestEventF>)
+    (reader : FifoEvents<TestEventF>)
+    (g : Generator<TestEventF>) =
+
+    let tefs = g |> Seq.take 3 |> Seq.toList
+
+    tefs |> List.iter (fun tef -> writer.AppendAsync(tef).Wait())
+    let actual = reader |> Seq.toList
+
+    let expected = tefs
+    Verify <@ expected = actual @>

--- a/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
+++ b/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
@@ -34,7 +34,7 @@ let SutCorrectlyRoundTripsMultipleElements
     Verify <@ expected = actual @>
 
 [<Theory; InMemoryDataContractConventions>]
-let SutCorrectlyRoundTripsChangesetOfDiscriminatedUnions
+let SutCorrectlyRoundTripsChangesetOfDiscriminatedUnion
     (writer : AtomEventObserver<Changeset<TestEvent>>)
     (reader : FifoEvents<Changeset<TestEvent>>)
     (tef : TestEventF)
@@ -44,8 +44,28 @@ let SutCorrectlyRoundTripsChangesetOfDiscriminatedUnions
     let expected = { Id = id; Items = [| tef |> F; teg |> G |] }
 
     writer.AppendAsync(expected).Wait()
-
     let actual = reader |> Seq.toList
 
     Verify <@ actual.Length = 1 @>
     Verify <@ expected = (actual |> Seq.exactlyOne) @>
+
+[<Theory; InMemoryDataContractConventions>]
+let SutCorrectlyRoundTripsMultipleChangesetOfDiscriminatedUnion
+    (writer : AtomEventObserver<Changeset<TestEvent>>)
+    (reader : FifoEvents<Changeset<TestEvent>>)
+    (tef1 : TestEventF)
+    (tef2 : TestEventF)
+    (teg1 : TestEventG)
+    (teg2 : TestEventG)
+    (id1 : Guid)
+    (id2 : Guid) =
+
+    let changeset1 = { Id = id1; Items = [| tef1 |> F; teg1 |> G |] }
+    let changeset2 = { Id = id2; Items = [| teg2 |> G; tef2 |> F |] }
+
+    writer.AppendAsync(changeset1).Wait()
+    writer.AppendAsync(changeset2).Wait()
+    let actual = reader |> Seq.toList
+
+    let expected = [changeset1; changeset2]
+    Verify <@ expected = actual @>

--- a/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
+++ b/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
@@ -1,5 +1,6 @@
 ﻿module Grean.AtomEventStore.UnitTests.FSharp.DataContractEventsFacadeTests
 
+open System
 open Grean.AtomEventStore
 open Grean.AtomEventStore.UnitTests.FSharp.DataContractRecords
 open Grean.AtomEventStore.UnitTests.FSharp.TestDsl
@@ -31,3 +32,20 @@ let SutCorrectlyRoundTripsMultipleElements
 
     let expected = tefs
     Verify <@ expected = actual @>
+
+[<Theory; InMemoryDataContractConventions>]
+let SutCorrectlyRoundTripsChangesetOfDiscriminatedUnions
+    (writer : AtomEventObserver<Changeset<TestEvent>>)
+    (reader : FifoEvents<Changeset<TestEvent>>)
+    (tef : TestEventF)
+    (teg : TestEventG)
+    (id : Guid) =
+
+    let expected = { Id = id; Items = [| tef |> F; teg |> G |] }
+
+    writer.AppendAsync(expected).Wait()
+
+    let actual = reader |> Seq.toList
+
+    Verify <@ actual.Length = 1 @>
+    Verify <@ expected = (actual |> Seq.exactlyOne) @>

--- a/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
+++ b/AtomEventStore.UnitTests.FSharp/DataContractEventsFacadeTests.fs
@@ -1,0 +1,18 @@
+﻿module Grean.AtomEventStore.UnitTests.FSharp.DataContractEventsFacadeTests
+
+open Grean.AtomEventStore
+open Grean.AtomEventStore.UnitTests.FSharp.DataContractRecords
+open Grean.AtomEventStore.UnitTests.FSharp.TestDsl
+open Xunit.Extensions
+
+[<Theory; InMemoryDataContractConventions>]
+let SutCorrectlyRoundTripsASingleElement
+    (writer : AtomEventObserver<TestEventF>)
+    (reader : FifoEvents<TestEventF>)
+    (tef : TestEventF) =
+
+    writer.AppendAsync(tef).Wait()
+    let actual = reader |> Seq.toList
+
+    Verify <@ actual.Length = 1 @>
+    Verify <@ actual |> Seq.exactlyOne = tef @>

--- a/AtomEventStore.UnitTests.FSharp/Records.fs
+++ b/AtomEventStore.UnitTests.FSharp/Records.fs
@@ -3,6 +3,8 @@
 open System
 open Grean.AtomEventStore
 
+exception UnknownTypeRequested of string * string
+
 module XmlRecords =    
     open System.Xml.Serialization
 
@@ -40,8 +42,6 @@ module XmlRecords =
         Id : Guid
         Items : TestEvent seq }
 
-    exception UnknownTypeRequested of string * string
-
     type TestRecordsResolver() =
         interface ITypeResolver with
             member this.Resolve(localName, xmlNamespace) =
@@ -52,4 +52,23 @@ module XmlRecords =
                     typeof<TestEventG>
                 | ("changeset", "http://grean.dk/atom-event-store/test/2014") ->
                     typeof<SerializableChangeset>
+                | _ -> raise(UnknownTypeRequested(localName, xmlNamespace))
+
+module DataContractRecords =
+    open System.Runtime.Serialization
+
+    [<CLIMutable>]
+    [<DataContract(Name = "test-event-f", Namespace = "http://grean.dk/atom-event-store/test/2014")>]
+    type TestEventF = {
+        [<DataMember(Name = "number")>]
+        Number : int
+        [<DataMember(Name = "text")>]
+        Text : string }
+
+    type TestRecordsResolver() =
+        interface ITypeResolver with
+            member this.Resolve(localName, xmlNamespace) =
+                match (localName, xmlNamespace) with
+                | ("test-event-f", "http://grean.dk/atom-event-store/test/2014") ->
+                    typeof<TestEventF>
                 | _ -> raise(UnknownTypeRequested(localName, xmlNamespace))

--- a/AtomEventStore.UnitTests.FSharp/Records.fs
+++ b/AtomEventStore.UnitTests.FSharp/Records.fs
@@ -1,53 +1,55 @@
 ﻿namespace Grean.AtomEventStore.UnitTests.FSharp
 
 open System
-open System.Xml.Serialization
 open Grean.AtomEventStore
 
-[<CLIMutable>]
-[<XmlRoot("test-event-f", Namespace = "http://grean.dk/atom-event-store/test/2014")>]
-type TestEventF = {
-    [<XmlElement("number")>]
-    Number : int
-    [<XmlElement("text")>]
-    Text : string }
+module XmlRecords =    
+    open System.Xml.Serialization
 
-[<CLIMutable>]
-[<XmlRoot("test-event-g", Namespace = "http://grean.dk/atom-event-store/test/2014")>]
-type TestEventG = {
-    [<XmlElement("number")>]
-    Number : byte
-    [<XmlElement("flag")>]
-    Flag : bool }
+    [<CLIMutable>]
+    [<XmlRoot("test-event-f", Namespace = "http://grean.dk/atom-event-store/test/2014")>]
+    type TestEventF = {
+        [<XmlElement("number")>]
+        Number : int
+        [<XmlElement("text")>]
+        Text : string }
 
-[<CLIMutable>]
-[<XmlRoot("changeset", Namespace = "http://grean.dk/atom-event-store/test/2014")>]
-type SerializableChangeset = {
-    [<XmlElement("id")>]
-    Id : Guid
-    [<XmlArray("items")>]
-    [<XmlArrayItem("test-event-f", typeof<TestEventF>)>]
-    [<XmlArrayItem("test-event-g", typeof<TestEventG>)>]
-    Items : obj array }
+    [<CLIMutable>]
+    [<XmlRoot("test-event-g", Namespace = "http://grean.dk/atom-event-store/test/2014")>]
+    type TestEventG = {
+        [<XmlElement("number")>]
+        Number : byte
+        [<XmlElement("flag")>]
+        Flag : bool }
 
-type TestEvent =
-    | F of TestEventF
-    | G of TestEventG
+    [<CLIMutable>]
+    [<XmlRoot("changeset", Namespace = "http://grean.dk/atom-event-store/test/2014")>]
+    type SerializableChangeset = {
+        [<XmlElement("id")>]
+        Id : Guid
+        [<XmlArray("items")>]
+        [<XmlArrayItem("test-event-f", typeof<TestEventF>)>]
+        [<XmlArrayItem("test-event-g", typeof<TestEventG>)>]
+        Items : obj array }
 
-type EventChangeset = {
-    Id : Guid
-    Items : TestEvent seq }
+    type TestEvent =
+        | F of TestEventF
+        | G of TestEventG
 
-exception UnknownTypeRequested of string * string
+    type EventChangeset = {
+        Id : Guid
+        Items : TestEvent seq }
 
-type TestRecordsResolver() =
-    interface ITypeResolver with
-        member this.Resolve(localName, xmlNamespace) =
-            match (localName, xmlNamespace) with
-            | ("test-event-f", "http://grean.dk/atom-event-store/test/2014") ->
-                typeof<TestEventF>
-            | ("test-event-g", "http://grean.dk/atom-event-store/test/2014") ->
-                typeof<TestEventG>
-            | ("changeset", "http://grean.dk/atom-event-store/test/2014") ->
-                typeof<SerializableChangeset>
-            | _ -> raise(UnknownTypeRequested(localName, xmlNamespace))
+    exception UnknownTypeRequested of string * string
+
+    type TestRecordsResolver() =
+        interface ITypeResolver with
+            member this.Resolve(localName, xmlNamespace) =
+                match (localName, xmlNamespace) with
+                | ("test-event-f", "http://grean.dk/atom-event-store/test/2014") ->
+                    typeof<TestEventF>
+                | ("test-event-g", "http://grean.dk/atom-event-store/test/2014") ->
+                    typeof<TestEventG>
+                | ("changeset", "http://grean.dk/atom-event-store/test/2014") ->
+                    typeof<SerializableChangeset>
+                | _ -> raise(UnknownTypeRequested(localName, xmlNamespace))

--- a/AtomEventStore.UnitTests.FSharp/TestDsl.fs
+++ b/AtomEventStore.UnitTests.FSharp/TestDsl.fs
@@ -27,7 +27,7 @@ type TestRecordsResolverCustomization() =
             fixture.Customizations.Add(
                 TypeRelay(
                     typeof<ITypeResolver>,
-                    typeof<TestRecordsResolver>))
+                    typeof<XmlRecords.TestRecordsResolver>))
 
 type InMemoryXmlCustomization() =
     inherit CompositeCustomization(

--- a/AtomEventStore.UnitTests.FSharp/TestDsl.fs
+++ b/AtomEventStore.UnitTests.FSharp/TestDsl.fs
@@ -1,17 +1,16 @@
 ﻿namespace Grean.AtomEventStore.UnitTests.FSharp
 
+open System.Reflection
 open Grean.AtomEventStore
 open Ploeh.AutoFixture
 open Ploeh.AutoFixture.Kernel
 open Ploeh.AutoFixture.Xunit
 
 type AtomStorageInMemoryCustomization() =
+    let storage = AtomEventsInMemory()
     interface ICustomization with
         member this.Customize fixture =
-            fixture.Customizations.Add(
-                TypeRelay(
-                    typeof<IAtomEventStorage>,
-                    typeof<AtomEventsInMemory>))
+            fixture.Inject<IAtomEventStorage> storage
 
 type XmlContentSerializerCustomization() =
     interface ICustomization with
@@ -21,7 +20,7 @@ type XmlContentSerializerCustomization() =
                     typeof<IContentSerializer>,
                     typeof<XmlContentSerializer>))
 
-type TestRecordsResolverCustomization() =
+type XmlTestRecordsResolverCustomization() =
     interface ICustomization with
         member this.Customize fixture =
             fixture.Customizations.Add(
@@ -29,14 +28,54 @@ type TestRecordsResolverCustomization() =
                     typeof<ITypeResolver>,
                     typeof<XmlRecords.TestRecordsResolver>))
 
+type DataContractContentSerializerCustomization() =
+    interface ICustomization with
+        member this.Customize fixture =
+            fixture.Customizations.Add(
+                TypeRelay(
+                    typeof<IContentSerializer>,
+                    typeof<DataContractContentSerializer>))
+
+type DataContracTestRecordsResolverCustomization() =
+    interface ICustomization with
+        member this.Customize fixture =
+            fixture.Customizations.Add(
+                TypeRelay(
+                    typeof<ITypeResolver>,
+                    typeof<DataContractRecords.TestRecordsResolver>))
+
 type InMemoryXmlCustomization() =
     inherit CompositeCustomization(
         AtomStorageInMemoryCustomization(),
         XmlContentSerializerCustomization(),
-        TestRecordsResolverCustomization())
+        XmlTestRecordsResolverCustomization())
 
 type InMemoryXmlConventions() =
     inherit AutoDataAttribute(Fixture().Customize(InMemoryXmlCustomization()))
+
+type FrozenEventsIdCustomization() =
+    let freezeEventsId id = {
+        new ISpecimenBuilder with
+            member this.Create(request, context) =
+                match request with
+                | :? ParameterInfo as param
+                    when param.ParameterType = typeof<UuidIri>
+                    && param.Name = "id" -> id
+                | _ -> NoSpecimen(request) :> obj }
+    interface ICustomization with
+        member this.Customize fixture =
+            let id = fixture.Create<UuidIri>()
+            fixture.Customizations.Add(freezeEventsId id)
+
+type InMemoryDataContractCustomization() =
+    inherit CompositeCustomization(
+        FrozenEventsIdCustomization(),
+        AtomStorageInMemoryCustomization(),
+        DataContractContentSerializerCustomization(),
+        DataContracTestRecordsResolverCustomization())
+
+type InMemoryDataContractConventions() =
+    inherit AutoDataAttribute(Fixture().Customize(InMemoryDataContractCustomization()))
 
 module TestDsl =
     let Verify = Swensen.Unquote.Assertions.test

--- a/AtomEventStore.UnitTests.FSharp/TestDsl.fs
+++ b/AtomEventStore.UnitTests.FSharp/TestDsl.fs
@@ -29,14 +29,14 @@ type TestRecordsResolverCustomization() =
                     typeof<ITypeResolver>,
                     typeof<TestRecordsResolver>))
 
-type InMemoryCustomization() =
+type InMemoryXmlCustomization() =
     inherit CompositeCustomization(
         AtomStorageInMemoryCustomization(),
         XmlContentSerializerCustomization(),
         TestRecordsResolverCustomization())
 
-type InMemoryConventions() =
-    inherit AutoDataAttribute(Fixture().Customize(InMemoryCustomization()))
+type InMemoryXmlConventions() =
+    inherit AutoDataAttribute(Fixture().Customize(InMemoryXmlCustomization()))
 
 module TestDsl =
     let Verify = Swensen.Unquote.Assertions.test

--- a/AtomEventStore.UnitTests.FSharp/XmlEventStreamFacadeTests.fs
+++ b/AtomEventStore.UnitTests.FSharp/XmlEventStreamFacadeTests.fs
@@ -8,7 +8,7 @@ open Grean.AtomEventStore.UnitTests.FSharp.TestDsl
 open Ploeh.AutoFixture
 open Xunit.Extensions
 
-module AtomEventStreamFacadeTests =
+module XmlEventStreamFacadeTests =
 
     [<Theory; InMemoryXmlConventions>]
     let SutCorrectlyRoundTripsASingleElement

--- a/AtomEventStore.UnitTests.FSharp/XmlEventStreamFacadeTests.fs
+++ b/AtomEventStore.UnitTests.FSharp/XmlEventStreamFacadeTests.fs
@@ -4,6 +4,7 @@ open System
 open System.Reactive
 open FSharp.Reactive
 open Grean.AtomEventStore
+open Grean.AtomEventStore.UnitTests.FSharp.XmlRecords
 open Grean.AtomEventStore.UnitTests.FSharp.TestDsl
 open Ploeh.AutoFixture
 open Xunit.Extensions


### PR DESCRIPTION
This merely captures some prototyping I'd been doing in FSI of how to serialize and deserialize changesets of Discriminated Unions.

Notice how much easier it is with DataContractSerializer compared to XmlSerializer.
