### PR TITLE
Marked a member as not CLS compliant, because

### DIFF
--- a/AtomEventStore.AzureBlob/AtomEventsOnAzure.cs
+++ b/AtomEventStore.AzureBlob/AtomEventsOnAzure.cs
@@ -13,6 +13,7 @@ namespace Grean.AtomEventStore.AzureBlob
     {
         private readonly CloudBlobContainer container;
 
+        [CLSCompliant(false)]
         public AtomEventsOnAzure(CloudBlobContainer container)
         {
             this.container = container;


### PR DESCRIPTION
CloudBlobContainer isn't CLS compliant.
