### PR TITLE
Indexed indexes

### DIFF
--- a/AtomEventStore.UnitTests/AtomEventObserverTests.cs
+++ b/AtomEventStore.UnitTests/AtomEventObserverTests.cs
@@ -346,9 +346,9 @@ namespace Grean.AtomEventStore.UnitTests
             var index = FindIndex(pages, id);
             var firstLink = index.Links.SingleOrDefault(l => l.IsFirstLink);
             Assert.NotNull(firstLink);
-            Guid g;
-            Assert.True(Guid.TryParse(firstLink.Href.ToString(), out g));
-            var firstPage = pages.SingleOrDefault(f => f.Id == (UuidIri)g);
+            //Guid g;
+            //Assert.True(Guid.TryParse(firstLink.Href.ToString(), out g));
+            var firstPage = pages.SingleOrDefault(f => f.Links.Single(l => l.IsSelfLink).Href == firstLink.Href);
             Assert.NotNull(firstPage);
             return firstPage;
         }
@@ -357,9 +357,9 @@ namespace Grean.AtomEventStore.UnitTests
         {
             var nextLink = page.Links.SingleOrDefault(l => l.IsNextLink);
             Assert.NotNull(nextLink);
-            Guid g;
-            Assert.True(Guid.TryParse(nextLink.Href.ToString(), out g));
-            var nextPage = pages.SingleOrDefault(f => f.Id == (UuidIri)g);
+            //Guid g;
+            //Assert.True(Guid.TryParse(nextLink.Href.ToString(), out g));
+            var nextPage = pages.SingleOrDefault(f => f.Links.Single(l => l.IsSelfLink).Href == nextLink.Href);
             Assert.NotNull(nextPage);
             return nextPage;
         }

--- a/AtomEventStore/AtomEventObserver.cs
+++ b/AtomEventStore/AtomEventObserver.cs
@@ -39,7 +39,7 @@ namespace Grean.AtomEventStore
                 var index = this.ReadIndex();
                 var firstLink = index.Links
                     .Where(l => l.IsFirstLink)
-                    .DefaultIfEmpty(AtomLink.CreateFirstLink(CreateNewFeedAddress()))
+                    .DefaultIfEmpty(AtomLink.CreateFirstLink(this.CreateNewFeedAddress()))
                     .Single();
                 var lastLink = index.Links.SingleOrDefault(l => l.IsLastLink);
                 var lastLinkChanged = false;
@@ -63,7 +63,7 @@ namespace Grean.AtomEventStore
 
                 if (lastPage.Entries.Count() >= this.pageSize)
                 {
-                    var nextAddress = CreateNewFeedAddress();
+                    var nextAddress = this.CreateNewFeedAddress();
                     var nextPage = this.ReadPage(nextAddress);
                     nextPage = AddEntryTo(nextPage, entry, now);
 
@@ -97,9 +97,10 @@ namespace Grean.AtomEventStore
             });
         }
 
-        private static Uri CreateNewFeedAddress()
+        private Uri CreateNewFeedAddress()
         {
-            return new Uri(Guid.NewGuid().ToString(), UriKind.Relative);
+            var indexedAddress = ((Guid)this.id) + "/" + Guid.NewGuid();
+            return new Uri(indexedAddress, UriKind.Relative);
         }
 
         private AtomFeed ReadIndex()

--- a/AtomEventStore/AtomEventObserver.cs
+++ b/AtomEventStore/AtomEventObserver.cs
@@ -106,7 +106,9 @@ namespace Grean.AtomEventStore
         private AtomFeed ReadIndex()
         {
             var indexAddress =
-                new Uri(((Guid)this.id).ToString(), UriKind.Relative);
+                new Uri(
+                    ((Guid)this.id) + "/" + ((Guid)this.id),
+                    UriKind.Relative);
             return ReadPage(indexAddress);
         }
 

--- a/AtomEventStore/AtomEventsInFiles.cs
+++ b/AtomEventStore/AtomEventsInFiles.cs
@@ -38,6 +38,8 @@ namespace Grean.AtomEventStore
                 throw new ArgumentNullException("atomFeed");
 
             var fileName = this.CreateFileName(atomFeed.Links);
+            var dir = Path.GetDirectoryName(fileName);
+            System.IO.Directory.CreateDirectory(dir);
             return XmlWriter.Create(fileName);
         }
 

--- a/AtomEventStore/FifoEvents.cs
+++ b/AtomEventStore/FifoEvents.cs
@@ -68,7 +68,9 @@ namespace Grean.AtomEventStore
         private AtomFeed ReadIndex()
         {
             var indexAddress =
-                new Uri(((Guid)this.id).ToString(), UriKind.Relative);
+                new Uri(
+                    ((Guid)this.id) + "/" + ((Guid)this.id),
+                    UriKind.Relative);
             return this.ReadPage(indexAddress);
         }
 


### PR DESCRIPTION
This Pull Request changes the storage algorithm for `AtomEventObserver<T>` and `FifoEvents<T>` (_not_ the legacy `AtomEventStream<T>`) to use 'subfolders' for indexing purposes.

Each event stream is now stored in its own 'subfolder', which enables efficient enumeration of all event streams in a system.
