### PR TITLE
Decrease coupling to convention based serializer

### DIFF
--- a/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
+++ b/AtomEventStore.UnitTests/AtomEventStore.UnitTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="AtomLinkTests.cs" />
     <Compile Include="AutoAtomDataAttribute.cs" />
     <Compile Include="AtomEventStreamTests.cs" />
+    <Compile Include="ConventionBasedSerializerOfComplexImmutableClassesTests.cs" />
     <Compile Include="DataContractContentSerializerTests.cs" />
     <Compile Include="DataContractTestEventX.cs" />
     <Compile Include="Disarray.cs" />

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -69,5 +69,21 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripItemWithUri(
+            XmlAtomContent seed,
+            TestEventU teu)
+        {
+            var expected = seed.WithItem(teu);
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -344,5 +344,21 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripEventWithDateTimeOffset(
+            XmlAtomContent seed,
+            TestEventD ted)
+        {
+            var expected = seed.WithItem(ted);
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -185,5 +185,21 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripCompositeFromSeveralNamespaces(
+            XmlAtomContent seed,
+            Envelope<SubNs.SubSubNs.TestEventS> env)
+        {
+            var expected = seed.WithItem(env);
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -245,5 +245,33 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeNestedEnumerable(
+            XmlAtomContent seed,
+            Guid id,
+            Wrapper<TestEventX> w)
+        {
+            var sut = seed.WithItem(new Changeset<Wrapper<TestEventX>>(id, w));
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <changeset xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <id>urn:uuid:" + id + "</id>" +
+                "    <wrapper>" +
+                "      <item>" +
+                "        <test-event-x>" +
+                "          <number>" + w.Item.Number + "</number>" +
+                "          <text>" + w.Item.Text + "</text>" +
+                "        </test-event-x>" +
+                "      </item>" +
+                "    </wrapper>" +
+                "  </changeset>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -38,16 +38,14 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundTripNestedItem(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Envelope<TestEventY> env)
         {
             var expected = seed.WithItem(env);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -126,5 +126,25 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeEventInSubNamespace(
+            XmlAtomContent seed,
+            SubNs.SubSubNs.TestEventS tes)
+        {
+            var sut = seed.WithItem(tes);
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <test-event-s xmlns=\"urn:grean:atom-event-store:unit-tests:sub-ns:sub-sub-ns\">" +
+                "    <number>" + tes.Number + "</number>" +
+                "    <text>" + tes.Text + "</text>" +
+                "  </test-event-s>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -163,13 +163,13 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeCompositeFromSeveralNamespaces(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Envelope<SubNs.SubSubNs.TestEventS> env)
         {
-            var sut = seed.WithItem(env);
+            var content = seed.WithItem(env);
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -228,5 +228,24 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundtripEnumerable(
+            XmlAtomContent seed,
+            Guid id,
+            TestEventX tex1,
+            TestEventY tey,
+            TestEventX tex2)
+        {
+            var expected = seed.WithItem(new Changeset<ITestEvent>(id, tex1, tey, tex2));
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -361,13 +361,13 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeSealedEvent(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             TestEventSealed tes)
         {
-            var sut = seed.WithItem(tes);
+            var content = seed.WithItem(tes);
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -112,5 +112,21 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripDoublyNestedItem(
+            XmlAtomContent seed,
+            Envelope<Wrapper<TestEventX>> env)
+        {
+            var expected = seed.WithItem(env);
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -3,10 +3,37 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Extensions;
 
 namespace Grean.AtomEventStore.UnitTests
 {
     public class ConventionBasedSerializerOfComplexImmutableClassesTests
     {
+        [Theory, AutoAtomData]
+        public void SutCanSerializeNestedItem(
+            XmlAtomContent seed,
+            Envelope<TestEventX> env)
+        {
+            var sut = seed.WithItem(env);
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <envelope xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <id>urn:uuid:" + env.Id + "</id>" +
+                "    <item>" +
+                "      <test-event-x>" +
+                "        <number>" + env.Item.Number + "</number>" +
+                "        <text>" + env.Item.Text + "</text>" +
+                "      </test-event-x>" +
+                "    </item>" +
+                "  </envelope>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -199,5 +199,34 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeEnumerable(
+            XmlAtomContent seed,
+            Guid id,
+            TestEventX tex,
+            TestEventY tey)
+        {
+            var sut = seed.WithItem(new Changeset<ITestEvent>(id, tex, tey));
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <changeset xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <id>urn:uuid:" + id + "</id>" +
+                "    <test-event-x>" +
+                "      <number>" + tex.Number + "</number>" +
+                "      <text>" + tex.Text + "</text>" +
+                "    </test-event-x>" +
+                "    <test-event-y>" +
+                "      <number>" + tey.Number + "</number>" +
+                "      <is-true>" + tey.IsTrue.ToString().ToLowerInvariant() + "</is-true>" +
+                "    </test-event-y>" +
+                "  </changeset>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -358,5 +358,25 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeSealedEvent(
+            XmlAtomContent seed,
+            TestEventSealed tes)
+        {
+            var sut = seed.WithItem(tes);
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <test-event-sealed xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <number>" + tes.Number + "</number>" +
+                "    <text>" + tes.Text + "</text>" +
+                "  </test-event-sealed>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -49,5 +49,25 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeItemWithUri(
+            XmlAtomContent seed,
+            TestEventU teu)
+        {
+            var sut = seed.WithItem(teu);
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <test-event-u xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <address>" + teu.Address.ToString() + "</address>" +
+                "    <text>" + teu.Text + "</text>" +
+                "  </test-event-u>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -381,16 +381,14 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundTripSealedEvent(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             TestEventSealed tes)
         {
             var expected = seed.WithItem(tes);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -231,6 +231,7 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundtripEnumerable(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Guid id,
             TestEventX tex1,
@@ -238,12 +239,9 @@ namespace Grean.AtomEventStore.UnitTests
             TestEventX tex2)
         {
             var expected = seed.WithItem(new Changeset<ITestEvent>(id, tex1, tey, tex2));
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -188,16 +188,14 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundTripCompositeFromSeveralNamespaces(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Envelope<SubNs.SubSubNs.TestEventS> env)
         {
             var expected = seed.WithItem(env);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -276,17 +276,15 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundTripNestedEnumerable(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Guid id,
             Wrapper<TestEventX> w)
         {
             var expected = seed.WithItem(new Changeset<Wrapper<TestEventX>>(id, w));
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -160,5 +160,30 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeCompositeFromSeveralNamespaces(
+            XmlAtomContent seed,
+            Envelope<SubNs.SubSubNs.TestEventS> env)
+        {
+            var sut = seed.WithItem(env);
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <envelope xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <id>urn:uuid:" + env.Id + "</id>" +
+                "    <item>" +
+                "      <test-event-s xmlns=\"urn:grean:atom-event-store:unit-tests:sub-ns:sub-sub-ns\">" +
+                "        <number>" + env.Item.Number + "</number>" +
+                "        <text>" + env.Item.Text + "</text>" +
+                "      </test-event-s>" +
+                "    </item>" +
+                "  </envelope>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -273,5 +273,22 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripNestedEnumerable(
+            XmlAtomContent seed,
+            Guid id,
+            Wrapper<TestEventX> w)
+        {
+            var expected = seed.WithItem(new Changeset<Wrapper<TestEventX>>(id, w));
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -248,14 +248,14 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeNestedEnumerable(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Guid id,
             Wrapper<TestEventX> w)
         {
-            var sut = seed.WithItem(new Changeset<Wrapper<TestEventX>>(id, w));
+            var content = seed.WithItem(new Changeset<Wrapper<TestEventX>>(id, w));
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -83,5 +83,34 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeDoublyNestedItem(
+            XmlAtomContent seed,
+            Envelope<Wrapper<TestEventX>> env)
+        {
+            var sut = seed.WithItem(env);
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <envelope xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <id>urn:uuid:" + env.Id + "</id>" +
+                "    <item>" +
+                "      <wrapper>" +
+                "        <item>" +
+                "          <test-event-x>" +
+                "            <number>" + env.Item.Item.Number + "</number>" +
+                "            <text>" + env.Item.Item.Text + "</text>" +
+                "          </test-event-x>" +
+                "        </item>" +
+                "      </wrapper>" +
+                "    </item>" +
+                "  </envelope>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -13,13 +13,13 @@ namespace Grean.AtomEventStore.UnitTests
     {
         [Theory, AutoAtomData]
         public void SutCanSerializeNestedItem(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Envelope<TestEventX> env)
         {
-            var sut = seed.WithItem(env);
+            var content = seed.WithItem(env);
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -308,5 +308,41 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeEvenWithZeroedOutSubSeconds(
+            DateTimeOffset dtSeed,
+            XmlAtomContent seed,
+            TestEventD ted)
+        {
+            /* The use of this particular constructor overload results in a
+             * loss of precision, since ticks below the millisecond granularity
+             * are lost. This causes ToString("o") to print trailing zeroes,
+             * and reproduces a non-deterministically failing test, that
+             * sometimes would fail because the actual implementation didn't 
+             * print the trailing zeroes. */
+            var dt = new DateTimeOffset(
+                dtSeed.Year,
+                dtSeed.Month,
+                dtSeed.Day,
+                dtSeed.Hour,
+                dtSeed.Minute,
+                dtSeed.Second,
+                dtSeed.Millisecond,
+                dtSeed.Offset);
+            var sut = seed.WithItem(ted.WithDateTime(dt));
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <test-event-d xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <number>" + ted.Number + "</number>" +
+                "    <date-time>" + dt.ToString("o") + "</date-time>" +
+                "  </test-event-d>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -291,13 +291,13 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeEventWithDateTimeOffset(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             TestEventD ted)
         {
-            var sut = seed.WithItem(ted);
+            var content = seed.WithItem(ted);
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -52,13 +52,13 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeItemWithUri(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             TestEventU teu)
         {
-            var sut = seed.WithItem(teu);
+            var content = seed.WithItem(teu);
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -86,13 +86,13 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeDoublyNestedItem(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Envelope<Wrapper<TestEventX>> env)
         {
-            var sut = seed.WithItem(env);
+            var content = seed.WithItem(env);
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -146,5 +146,19 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripEventInSubNamespace(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
+            XmlAtomContent seed,
+            SubNs.SubSubNs.TestEventS tes)
+        {
+            var expected = seed.WithItem(tes);
+            var xml = expected.ToXmlString(sut);
+
+            var actual = XmlAtomContent.Parse(xml, sut);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -115,16 +115,14 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundTripDoublyNestedItem(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Envelope<Wrapper<TestEventX>> env)
         {
             var expected = seed.WithItem(env);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -72,16 +72,14 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundTripItemWithUri(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             TestEventU teu)
         {
             var expected = seed.WithItem(teu);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -311,6 +311,7 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeEvenWithZeroedOutSubSeconds(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             DateTimeOffset dtSeed,
             XmlAtomContent seed,
             TestEventD ted)
@@ -330,10 +331,9 @@ namespace Grean.AtomEventStore.UnitTests
                 dtSeed.Second,
                 dtSeed.Millisecond,
                 dtSeed.Offset);
-            var sut = seed.WithItem(ted.WithDateTime(dt));
+            var content = seed.WithItem(ted.WithDateTime(dt));
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grean.AtomEventStore.UnitTests
+{
+    public class ConventionBasedSerializerOfComplexImmutableClassesTests
+    {
+    }
+}

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -202,15 +202,15 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeEnumerable(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             Guid id,
             TestEventX tex,
             TestEventY tey)
         {
-            var sut = seed.WithItem(new Changeset<ITestEvent>(id, tex, tey));
+            var content = seed.WithItem(new Changeset<ITestEvent>(id, tex, tey));
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -288,5 +288,25 @@ namespace Grean.AtomEventStore.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanSerializeEventWithDateTimeOffset(
+            XmlAtomContent seed,
+            TestEventD ted)
+        {
+            var sut = seed.WithItem(ted);
+
+            var actual = sut.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var expected = XDocument.Parse(
+                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "  <test-event-d xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
+                "    <number>" + ted.Number + "</number>" +
+                "    <date-time>" + ted.DateTime.ToString("o") + "</date-time>" +
+                "  </test-event-d>" +
+                "</content>");
+            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -378,5 +378,21 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripSealedEvent(
+            XmlAtomContent seed,
+            TestEventSealed tes)
+        {
+            var expected = seed.WithItem(tes);
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -129,13 +129,13 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanSerializeEventInSubNamespace(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             SubNs.SubSubNs.TestEventS tes)
         {
-            var sut = seed.WithItem(tes);
+            var content = seed.WithItem(tes);
 
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = content.ToXmlString(sut);
 
             var expected = XDocument.Parse(
                 "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -35,5 +35,21 @@ namespace Grean.AtomEventStore.UnitTests
                 "</content>");
             Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
         }
+
+        [Theory, AutoAtomData]
+        public void SutCanRoundTripNestedItem(
+            XmlAtomContent seed,
+            Envelope<TestEventY> env)
+        {
+            var expected = seed.WithItem(env);
+            var xml = expected.ToXmlString(
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            var actual = XmlAtomContent.Parse(
+                xml,
+                new ConventionBasedSerializerOfComplexImmutableClasses());
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
+++ b/AtomEventStore.UnitTests/ConventionBasedSerializerOfComplexImmutableClassesTests.cs
@@ -347,16 +347,14 @@ namespace Grean.AtomEventStore.UnitTests
 
         [Theory, AutoAtomData]
         public void SutCanRoundTripEventWithDateTimeOffset(
+            ConventionBasedSerializerOfComplexImmutableClasses sut,
             XmlAtomContent seed,
             TestEventD ted)
         {
             var expected = seed.WithItem(ted);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var xml = expected.ToXmlString(sut);
 
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
+            var actual = XmlAtomContent.Parse(xml, sut);
 
             Assert.Equal(expected, actual);
         }

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,31 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeCompositeFromSeveralNamespaces(
-            XmlAtomContent seed,
-            Envelope<SubNs.SubSubNs.TestEventS> env)
-        {
-            var sut = seed.WithItem(env);
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <envelope xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <id>urn:uuid:" + env.Id + "</id>" +
-                "    <item>" +
-                "      <test-event-s xmlns=\"urn:grean:atom-event-store:unit-tests:sub-ns:sub-sub-ns\">" +
-                "        <number>" + env.Item.Number + "</number>" +
-                "        <text>" + env.Item.Text + "</text>" +
-                "      </test-event-s>" +
-                "    </item>" +
-                "  </envelope>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripCompositeFromSeveralNamespaces(
             XmlAtomContent seed,
             Envelope<SubNs.SubSubNs.TestEventS> env)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,22 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundTripNestedItem(
-            XmlAtomContent seed,
-            Envelope<TestEventY> env)
-        {
-            var expected = seed.WithItem(env);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeItemWithUri(
             XmlAtomContent seed,
             TestEventU teu)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,26 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeEventWithDateTimeOffset(
-            XmlAtomContent seed,
-            TestEventD ted)
-        {
-            var sut = seed.WithItem(ted);
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <test-event-d xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <number>" + ted.Number + "</number>" +
-                "    <date-time>" + ted.DateTime.ToString("o") + "</date-time>" +
-                "  </test-event-d>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeEvenWithZeroedOutSubSeconds(
             DateTimeOffset dtSeed,
             XmlAtomContent seed,

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,35 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeDoublyNestedItem(
-            XmlAtomContent seed,
-            Envelope<Wrapper<TestEventX>> env)
-        {
-            var sut = seed.WithItem(env);
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <envelope xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <id>urn:uuid:" + env.Id + "</id>" +
-                "    <item>" +
-                "      <wrapper>" +
-                "        <item>" +
-                "          <test-event-x>" +
-                "            <number>" + env.Item.Item.Number + "</number>" +
-                "            <text>" + env.Item.Item.Text + "</text>" +
-                "          </test-event-x>" +
-                "        </item>" +
-                "      </wrapper>" +
-                "    </item>" +
-                "  </envelope>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripDoublyNestedItem(
             XmlAtomContent seed,
             Envelope<Wrapper<TestEventX>> env)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,22 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundTripEventWithDateTimeOffset(
-            XmlAtomContent seed,
-            TestEventD ted)
-        {
-            var expected = seed.WithItem(ted);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeSealedEvent(
             XmlAtomContent seed,
             TestEventSealed tes)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,22 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundTripDoublyNestedItem(
-            XmlAtomContent seed,
-            Envelope<Wrapper<TestEventX>> env)
-        {
-            var expected = seed.WithItem(env);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeEventInSubNamespace(
             XmlAtomContent seed,
             SubNs.SubSubNs.TestEventS tes)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,26 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeSealedEvent(
-            XmlAtomContent seed,
-            TestEventSealed tes)
-        {
-            var sut = seed.WithItem(tes);
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <test-event-sealed xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <number>" + tes.Number + "</number>" +
-                "    <text>" + tes.Text + "</text>" +
-                "  </test-event-sealed>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripSealedEvent(
             XmlAtomContent seed,
             TestEventSealed tes)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,31 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeNestedItem(
-            XmlAtomContent seed,
-            Envelope<TestEventX> env)
-        {
-            var sut = seed.WithItem(env);
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <envelope xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <id>urn:uuid:" + env.Id + "</id>" +
-                "    <item>" +
-                "      <test-event-x>" +
-                "        <number>" + env.Item.Number + "</number>" +
-                "        <text>" + env.Item.Text + "</text>" +
-                "      </test-event-x>" +
-                "    </item>" +
-                "  </envelope>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripNestedItem(
             XmlAtomContent seed,
             Envelope<TestEventY> env)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,25 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundtripEnumerable(
-            XmlAtomContent seed,
-            Guid id,
-            TestEventX tex1,
-            TestEventY tey,
-            TestEventX tex2)
-        {
-            var expected = seed.WithItem(new Changeset<ITestEvent>(id, tex1, tey, tex2));
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeNestedEnumerable(
             XmlAtomContent seed,
             Guid id,

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,22 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundTripEventInSubNamespace(
-            XmlAtomContent seed,
-            SubNs.SubSubNs.TestEventS tes)
-        {
-            var expected = seed.WithItem(tes);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeCompositeFromSeveralNamespaces(
             XmlAtomContent seed,
             Envelope<SubNs.SubSubNs.TestEventS> env)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,22 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundTripCompositeFromSeveralNamespaces(
-            XmlAtomContent seed,
-            Envelope<SubNs.SubSubNs.TestEventS> env)
-        {
-            var expected = seed.WithItem(env);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeEnumerable(
             XmlAtomContent seed,
             Guid id,

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,23 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundTripNestedEnumerable(
-            XmlAtomContent seed,
-            Guid id,
-            Wrapper<TestEventX> w)
-        {
-            var expected = seed.WithItem(new Changeset<Wrapper<TestEventX>>(id, w));
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeEventWithDateTimeOffset(
             XmlAtomContent seed,
             TestEventD ted)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -144,22 +144,6 @@ namespace Grean.AtomEventStore.UnitTests
             Assert.Equal(expected, actual);
         }
 
-        [Theory, AutoAtomData]
-        public void SutCanRoundTripSealedEvent(
-            XmlAtomContent seed,
-            TestEventSealed tes)
-        {
-            var expected = seed.WithItem(tes);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
         [Theory]
         [InlineAutoAtomData("<Content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">", "</Content>")]
         [InlineAutoAtomData("<foo type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">", "</foo>")]

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,26 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeEventInSubNamespace(
-            XmlAtomContent seed,
-            SubNs.SubSubNs.TestEventS tes)
-        {
-            var sut = seed.WithItem(tes);
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <test-event-s xmlns=\"urn:grean:atom-event-store:unit-tests:sub-ns:sub-sub-ns\">" +
-                "    <number>" + tes.Number + "</number>" +
-                "    <text>" + tes.Text + "</text>" +
-                "  </test-event-s>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripEventInSubNamespace(
             XmlAtomContent seed,
             SubNs.SubSubNs.TestEventS tes)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,22 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanRoundTripItemWithUri(
-            XmlAtomContent seed,
-            TestEventU teu)
-        {
-            var expected = seed.WithItem(teu);
-            var xml = expected.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var actual = XmlAtomContent.Parse(
-                xml,
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanSerializeDoublyNestedItem(
             XmlAtomContent seed,
             Envelope<Wrapper<TestEventX>> env)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,42 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeEvenWithZeroedOutSubSeconds(
-            DateTimeOffset dtSeed,
-            XmlAtomContent seed,
-            TestEventD ted)
-        {
-            /* The use of this particular constructor overload results in a
-             * loss of precision, since ticks below the millisecond granularity
-             * are lost. This causes ToString("o") to print trailing zeroes,
-             * and reproduces a non-deterministically failing test, that
-             * sometimes would fail because the actual implementation didn't 
-             * print the trailing zeroes. */
-            var dt = new DateTimeOffset(
-                dtSeed.Year,
-                dtSeed.Month,
-                dtSeed.Day,
-                dtSeed.Hour,
-                dtSeed.Minute,
-                dtSeed.Second,
-                dtSeed.Millisecond,
-                dtSeed.Offset);
-            var sut = seed.WithItem(ted.WithDateTime(dt));
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <test-event-d xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <number>" + ted.Number + "</number>" +
-                "    <date-time>" + dt.ToString("o") + "</date-time>" +
-                "  </test-event-d>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripEventWithDateTimeOffset(
             XmlAtomContent seed,
             TestEventD ted)

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,35 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeEnumerable(
-            XmlAtomContent seed,
-            Guid id,
-            TestEventX tex,
-            TestEventY tey)
-        {
-            var sut = seed.WithItem(new Changeset<ITestEvent>(id, tex, tey));
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <changeset xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <id>urn:uuid:" + id + "</id>" +
-                "    <test-event-x>" +
-                "      <number>" + tex.Number + "</number>" +
-                "      <text>" + tex.Text + "</text>" +
-                "    </test-event-x>" +
-                "    <test-event-y>" +
-                "      <number>" + tey.Number + "</number>" +
-                "      <is-true>" + tey.IsTrue.ToString().ToLowerInvariant() + "</is-true>" +
-                "    </test-event-y>" +
-                "  </changeset>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundtripEnumerable(
             XmlAtomContent seed,
             Guid id,

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,34 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeNestedEnumerable(
-            XmlAtomContent seed,
-            Guid id,
-            Wrapper<TestEventX> w)
-        {
-            var sut = seed.WithItem(new Changeset<Wrapper<TestEventX>>(id, w));
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <changeset xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <id>urn:uuid:" + id + "</id>" +
-                "    <wrapper>" +
-                "      <item>" +
-                "        <test-event-x>" +
-                "          <number>" + w.Item.Number + "</number>" +
-                "          <text>" + w.Item.Text + "</text>" +
-                "        </test-event-x>" +
-                "      </item>" +
-                "    </wrapper>" +
-                "  </changeset>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripNestedEnumerable(
             XmlAtomContent seed,
             Guid id,

--- a/AtomEventStore.UnitTests/XmlAtomContentTests.cs
+++ b/AtomEventStore.UnitTests/XmlAtomContentTests.cs
@@ -145,26 +145,6 @@ namespace Grean.AtomEventStore.UnitTests
         }
 
         [Theory, AutoAtomData]
-        public void SutCanSerializeItemWithUri(
-            XmlAtomContent seed,
-            TestEventU teu)
-        {
-            var sut = seed.WithItem(teu);
-
-            var actual = sut.ToXmlString(
-                new ConventionBasedSerializerOfComplexImmutableClasses());
-
-            var expected = XDocument.Parse(
-                "<content type=\"application/xml\" xmlns=\"http://www.w3.org/2005/Atom\">" +
-                "  <test-event-u xmlns=\"urn:grean:atom-event-store:unit-tests\">" +
-                "    <address>" + teu.Address.ToString() + "</address>" +
-                "    <text>" + teu.Text + "</text>" +
-                "  </test-event-u>" +
-                "</content>");
-            Assert.Equal(expected, XDocument.Parse(actual), new XNodeEqualityComparer());
-        }
-
-        [Theory, AutoAtomData]
         public void SutCanRoundTripItemWithUri(
             XmlAtomContent seed,
             TestEventU teu)


### PR DESCRIPTION
This iteration moves tests that actually test the convention-based serializer to a separate test class, as preparation to moving the serializer to a separate library.
